### PR TITLE
Make Protobuf installation optional

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,14 +23,7 @@ if [ "${RESULT}" -ne 0 ]; then
     exit $?
 fi
 
-rm -r kortex_api/cpp/linux_gcc_x86-64/include/ src/ros_kortex/kortex_api/include/google/
-RESULT=$?
-if [ "${RESULT}" -ne 0 ]; then
-    echo "ERROR while deleting unused include folder. code = ${RESULT}"
-    exit $?
-fi
-
-cp -R kortex_api/cpp/linux_gcc_x86-64/lib/release/ src/ros_kortex/kortex_api/lib/
+cp -R kortex_api/cpp/linux_gcc_x86-64/lib/ src/ros_kortex/kortex_api/lib/
 RESULT=$?
 if [ "${RESULT}" -ne 0 ]; then
     echo "ERROR while copying the kortex api library. code = ${RESULT}"

--- a/kortex_actuator_driver/CMakeLists.txt
+++ b/kortex_actuator_driver/CMakeLists.txt
@@ -24,6 +24,7 @@ catkin_package()
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 include_directories(include ${PROJECT_SOURCE_DIR}/src)
+include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/client)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/client_stubs)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/messages)

--- a/kortex_device_manager/CMakeLists.txt
+++ b/kortex_device_manager/CMakeLists.txt
@@ -23,6 +23,7 @@ catkin_package()
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 include_directories(include ${PROJECT_SOURCE_DIR}/src)
+include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/client)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/client_stubs)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/messages)

--- a/kortex_driver/CMakeLists.txt
+++ b/kortex_driver/CMakeLists.txt
@@ -24,6 +24,7 @@ catkin_package()
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 include_directories(include ${PROJECT_SOURCE_DIR}/src)
+include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/client)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/client_stubs)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/messages)

--- a/kortex_vision_config_driver/CMakeLists.txt
+++ b/kortex_vision_config_driver/CMakeLists.txt
@@ -24,6 +24,7 @@ catkin_package()
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 include_directories(include ${PROJECT_SOURCE_DIR}/src)
+include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/client)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/client_stubs)
 include_directories(include ${PROJECT_SOURCE_DIR}/../kortex_api/include/messages)

--- a/readme.md
+++ b/readme.md
@@ -46,11 +46,6 @@ This package contains the URDF and the STL of a complete Gen3 robot. A more deta
 This package contains all the header files and the libraries required by the Kortex C++ API. A more detailed [description](kortex_api/readme.md) can be found in the package subdirectory.
 
 ## Setup
-### Install protobuf
-The protobuf compiler is required if you need to re-generate the original package code.
-
-1. git clone https://github.com/protocolbuffers/protobuf --branch 3.5.1.1   (you must use this specific version)
-2. Follow these [instructions](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md) to build and install protobuf and its compiler. 
 
 ### Download the API and extract it to the kortex_api/include and kortex_api/lib folders
 The build.sh script automates this process. To launch it, go to the root of your catkin_workspace and execute :
@@ -58,6 +53,12 @@ The build.sh script automates this process. To launch it, go to the root of your
 This will download the API, unzip it to the right folder and build the project with ```catkin_make```.
 
 You can also download and unzip the API manually by following these [instructions](kortex_api/readme.md).
+
+### Install protobuf [OPTIONAL]
+The protobuf compiler is not required if you want to use the package as is, but is required if you need to [re-generate](./generate_all.sh) the .MSG, .SRV and auto-generated Kortex-ROS C++ wrapper files.
+
+1. git clone https://github.com/protocolbuffers/protobuf --branch 3.5.1.1   (you must use this specific version)
+2. Follow these [instructions](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md) to build and install protobuf and its compiler. 
 
 ## kortex gazebo
 This package is not completed yet but will be available in a future version.


### PR DESCRIPTION
Changed the build.sh script to keep the google include folder, changed the CMakeLists.txt and the readme to make protobuf installation optional.
Relates to #23.