### PR TITLE
Support catkin_make install

### DIFF
--- a/kortex_control/CMakeLists.txt
+++ b/kortex_control/CMakeLists.txt
@@ -8,7 +8,8 @@ catkin_package()
 
 find_package(roslaunch)
 
-foreach(dir config launch meshes urdf)
+# Install
+foreach(dir arms grippers)
 	install(DIRECTORY ${dir}/
 		DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
 endforeach(dir)

--- a/kortex_description/CMakeLists.txt
+++ b/kortex_description/CMakeLists.txt
@@ -8,7 +8,8 @@ catkin_package()
 
 find_package(roslaunch)
 
-foreach(dir config launch meshes urdf)
+# Install
+foreach(dir arms grippers robots)
 	install(DIRECTORY ${dir}/
 		DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
 endforeach(dir)

--- a/kortex_driver/CMakeLists.txt
+++ b/kortex_driver/CMakeLists.txt
@@ -84,3 +84,24 @@ add_dependencies(kortex_driver_generated_files ${PROJECT_NAME}_gencpp)
 add_executable(kortex_arm_driver ${non_generated_files})
 target_link_libraries(kortex_arm_driver ${catkin_LIBRARIES} KortexApi gcov kortex_driver_generated_files)
 add_dependencies(kortex_arm_driver kortex_driver_generated_files)
+
+# Install
+
+install(TARGETS kortex_driver_generated_files kortex_arm_driver
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/../kortex_api/include/
+   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  FILES_MATCHING PATTERN "*.launch"
+)

--- a/kortex_examples/CMakeLists.txt
+++ b/kortex_examples/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs message_generation
 
 ## Declare a catkin package
 catkin_package()
-catkin_python_setup()
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 include_directories(include ${PROJECT_SOURCE_DIR}/src)
@@ -34,3 +33,33 @@ target_link_libraries(example_full_arm_movement_cpp ${catkin_LIBRARIES} )
 add_executable(example_cartesian_poses_with_notifications_cpp cpp/full_arm/example_cartesian_poses_with_notifications.cpp)
 add_dependencies(example_cartesian_poses_with_notifications_cpp ${catkin_EXPORTED_TARGETS})
 target_link_libraries(example_cartesian_poses_with_notifications_cpp ${catkin_LIBRARIES} )
+
+# Install
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   python/actuator_config/example_actuator_configuration.py
+#   python/full_arm/example_cartesian_poses_with_notifications.py
+#   python/full_arm/example_full_arm_movement.py
+#   python/move_it/example_move_it_trajectories.py
+#   python/vision_config/example_vision_configuration.py
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+catkin_install_python(PROGRAMS python/actuator_config/example_actuator_configuration.py
+                               python/full_arm/example_cartesian_poses_with_notifications.py
+                               python/full_arm/example_full_arm_movement.py
+                               python/move_it/example_move_it_trajectories.py
+                               python/vision_config/example_vision_configuration.py 
+                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+## Mark executables and/or libraries for installation
+install(TARGETS 
+    example_actuator_configuration_cpp
+    example_vision_configuration_cpp
+    example_full_arm_movement_cpp
+    example_cartesian_poses_with_notifications_cpp
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/kortex_examples/setup.py
+++ b/kortex_examples/setup.py
@@ -1,7 +1,0 @@
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
-
-setup(**generate_distutils_setup(
-    packages=['kortex_examples'],
-    package_dir={'': 'python'}
-))

--- a/kortex_gazebo/CMakeLists.txt
+++ b/kortex_gazebo/CMakeLists.txt
@@ -13,11 +13,6 @@ catkin_package()
 
 find_package(roslaunch)
 
-foreach(dir config launch meshes urdf)
-	install(DIRECTORY ${dir}/
-		DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
-
 # Gazebo is compiled with Protobuf 2.6.1 and Kortex with Protobuf 3.5.1
 # The 2.6.1 includes are prepended to the include_directories so the Gazebo plugins we compile here build
 include_directories(BEFORE ./include/)
@@ -28,3 +23,15 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 # To add your Gazebo plugin to this package, put your source file under src and uncomment/modify those lines
 # add_library(my_gazebo_plugin SHARED src/my_gazebo_plugin.cpp)
 # target_link_libraries(my_gazebo_plugin ${GAZEBO_LIBRARIES})
+
+
+# Install
+install(PROGRAMS
+  scripts/home_robot.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  FILES_MATCHING PATTERN "*.launch"
+)


### PR DESCRIPTION
With those changes, the install folder is properly built when running ```catkin_make install```.
Addresses #48 