### PR TITLE
Fix bug in documentation (and default value) for default_goal_tolerance

### DIFF
--- a/kortex_driver/launch/kortex_driver.launch
+++ b/kortex_driver/launch/kortex_driver.launch
@@ -19,7 +19,7 @@
 
     <!-- Action server params -->
     <arg name="default_goal_time_tolerance" default="0.5"/> <!--seconds-->
-    <arg name="default_goal_tolerance" default="0.5"/> <!--degrees-->
+    <arg name="default_goal_tolerance" default="0.005"/> <!--radians-->
 
     <group ns="$(arg robot_name)">
 

--- a/kortex_driver/readme.md
+++ b/kortex_driver/readme.md
@@ -60,7 +60,7 @@ The `kortex_driver` node is the node responsible for the communication between t
 - **start_moveit** : If this argument is true, a MoveIt! MoveGroup will be launched for the robot. The default value is **true**.
 
 - **default_goal_time_tolerance** : The default goal time tolerance for the `FollowJointTrajectory` action server, in seconds. This value is used if no default goal time tolerance is specified in the trajectory. The default value is **0.5** seconds.
-- **default_goal_tolerance** : The default goal tolerance for the `FollowJointTrajectory` action server, in degrees. This value is used if no default goal tolerance is specified in the trajectory for the joint positions reached at the end of the trajectory. The default value is **0.5** degrees.
+- **default_goal_tolerance** : The default goal tolerance for the `FollowJointTrajectory` action server, in radians. This value is used if no default goal tolerance is specified in the trajectory for the joint positions reached at the end of the trajectory. The default value is **0.005** radians.
 
 To launch it with default arguments, run the following command in a terminal : 
 

--- a/kortex_driver/src/non-generated/pre_computed_joint_trajectory_action_server.cpp
+++ b/kortex_driver/src/non-generated/pre_computed_joint_trajectory_action_server.cpp
@@ -30,8 +30,8 @@ PreComputedJointTrajectoryActionServer::PreComputedJointTrajectoryActionServer(c
     }
     if (!ros::param::get("~default_goal_tolerance", m_default_goal_tolerance))
     {
-        ROS_WARN("Parameter default_goal_tolerance was not specified; assuming 0.5 as default value.");
-        m_default_goal_time_tolerance = 0.5;
+        ROS_WARN("Parameter default_goal_tolerance was not specified; assuming 0.005 radians as default value.");
+        m_default_goal_time_tolerance = 0.005;
     }
     if (!ros::param::get("~joint_names", m_joint_names))
     {
@@ -444,7 +444,7 @@ bool PreComputedJointTrajectoryActionServer::is_goal_tolerance_respected(bool en
     std::vector<double> goal_tolerances;
     if (goal->goal_tolerance.empty())
     {
-        ROS_DEBUG("Goal did not specify tolerances, using default tolerance of %f degrees for every joint.", m_default_goal_tolerance);
+        ROS_DEBUG("Goal did not specify tolerances, using default tolerance of %f radians for every joint.", m_default_goal_tolerance);
         for (int i = 0; i < m_joint_names.size(); i++)
         {
             goal_tolerances.push_back(m_default_goal_tolerance);


### PR DESCRIPTION
Despite the documentation and debug messages, this value is assumed to be in radians and is converted .toDeg (from radians) on line 476 of pre_computed_joint_trajectory_action_server.cpp. This pull-request updates documentation, debug messages, and default value accordingly. Another possible fix would be to change the code to match the documentation instead (and not convert this value from degrees to radians on line 476 of pre_computed_joint_trajectory_action_server.cpp). However I think this is the better fix, since the client is already using radians inside the trajectory_msgs/JointTrajectory msg anyway, so this reduces the number of units the client has to think in.