### PR TITLE
ros_kortex_vision requires the robot description to contain the camera module frames

### DIFF
--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -312,5 +312,25 @@
       <axis
         xyz="0 0 0" />
     </joint>
+    <xacro:if value="${vision}">
+      <link name="${prefix}camera_link" />
+      <joint name="${prefix}camera_module" type="fixed">
+        <origin xyz="0 0.05639 -0.00305" rpy="3.14159265358979 3.14159265358979 0" />
+        <parent link="${prefix}end_effector_link" />
+        <child  link="${prefix}camera_link" />
+      </joint>
+      <link name="${prefix}camera_depth_frame" />
+      <joint name="${prefix}depth_module" type="fixed">
+        <origin xyz="0.0275 0.066 -0.00305" rpy="3.14159265358979 3.14159265358979 0" />
+        <parent link="${prefix}end_effector_link" />
+        <child  link="${prefix}camera_depth_frame" />
+      </joint>
+      <link name="${prefix}camera_color_frame" />
+      <joint name="${prefix}color_module" type="fixed">
+        <origin xyz="0 0.05639 -0.00305" rpy="3.14159265358979 3.14159265358979 0" />
+        <parent link="${prefix}end_effector_link" />
+        <child  link="${prefix}camera_color_frame" />
+      </joint>
+    </xacro:if>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
Added camera frames to gen3-7dof description so the vision module can work correctly.
Frames added:
- camera_link
- camera_depth_frame
- camera_color_frame
