### PR TITLE
Support for cakin_make_isolated and catkin tools

### DIFF
--- a/kortex_driver/CMakeLists.txt
+++ b/kortex_driver/CMakeLists.txt
@@ -11,19 +11,6 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-if(USE_CONAN)
-  # Include conan.cmake module and download Kortex API from artifactory
-  include(${PROJECT_SOURCE_DIR}/cmake/conan.cmake)
-  conan_check(REQUIRED)
-  conan_add_remote(NAME kinova_public
-                  URL https://artifactory.kinovaapps.com/artifactory/api/conan/conan-public)
-  conan_cmake_run(CONANFILE conanfile.py
-                  UPDATE
-                  BASIC_SETUP CMAKE_TARGETS
-                  NO_OUTPUT_DIRS
-                  SETTINGS kortex_api_cpp:compiler=gcc kortex_api_cpp:compiler.version=5 kortex_api_cpp:compiler.libcxx=libstdc++11)
-endif()
-
 ## find catkin and any catkin packages
 find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs message_generation actionlib control_msgs urdf)
 find_package(Boost REQUIRED COMPONENTS system)
@@ -67,6 +54,19 @@ generate_messages(DEPENDENCIES std_msgs)
 
 ## declare a catkin package
 catkin_package()
+
+if(USE_CONAN)
+  # Include conan.cmake module and download Kortex API from artifactory
+  include(${PROJECT_SOURCE_DIR}/cmake/conan.cmake)
+  conan_check(REQUIRED)
+  conan_add_remote(NAME kinova_public
+                  URL https://artifactory.kinovaapps.com/artifactory/api/conan/conan-public)
+  conan_cmake_run(CONANFILE conanfile.py
+                  UPDATE
+                  BASIC_SETUP CMAKE_TARGETS
+                  NO_OUTPUT_DIRS
+                  SETTINGS kortex_api_cpp:compiler=gcc kortex_api_cpp:compiler.version=5 kortex_api_cpp:compiler.libcxx=libstdc++11)
+endif()
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 include_directories(include ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
Addresses #84 

I found out the conan_cmake_run affects the CMAKE_PREFIX_PATH variable, and while this doesn't cause problems when building with `catkin_make`, it fails the build with `catkin_make_isolated` and `catkin build` because find_package() doesn't find core ROS packages (as roscpp).

Since the Kortex API is only needed when creating the targets, I moved the Conan calls right after `catkin_package()` and managed to build with : 
- `catkin_make`, with USE_CONAN both enabled and disabled
- `catkin_make_isolated --build build_isolated --devel devel_isolated --merge`, with USE_CONAN both enabled and disabled
- `catkin build`, with USE_CONAN both enabled and disabled

This was all tested on ROS Melodic, but I don't see why this wouldn't build on ROS Kinetic too.