### PR TITLE
Add colours to Gen3 lite simulation

### DIFF
--- a/kortex_description/arms/gen3_lite/6dof/urdf/gen3_lite_macro.xacro
+++ b/kortex_description/arms/gen3_lite/6dof/urdf/gen3_lite_macro.xacro
@@ -28,6 +28,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}base_link">
+      <material>Kortex/Gray</material>
+    </gazebo>
     <link name="${prefix}shoulder_link">
       <inertial>
         <origin xyz="2.477E-05 0.02213531 0.09937686" rpy="0 0 0" />
@@ -50,6 +53,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}shoulder_link">
+      <material>Kortex/Gray</material>
+    </gazebo>
     <joint name="${prefix}joint_1" type="revolute">
       <origin xyz="0 0 0.12825" rpy="0 0 0" />
       <parent link="${prefix}base_link" />
@@ -79,6 +85,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}arm_link">
+      <material>Kortex/Gray</material>
+    </gazebo>
     <joint name="${prefix}joint_2" type="revolute">
       <origin xyz="0 -0.03 0.115" rpy="1.5708 0 0" />
       <parent link="${prefix}shoulder_link" />
@@ -108,6 +117,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}forearm_link">
+      <material>Kortex/Gray</material>
+    </gazebo>
     <joint name="${prefix}joint_3" type="revolute">
       <origin xyz="0 0.28 0" rpy="-3.1416 0 0" />
       <parent link="${prefix}arm_link" />
@@ -137,6 +149,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}lower_wrist_link">
+      <material>Kortex/Gray</material>
+    </gazebo>
     <joint name="${prefix}joint_4" type="revolute">
       <origin xyz="0 -0.14 0.02" rpy="1.5708 0 0" />
       <parent link="${prefix}forearm_link" />
@@ -166,6 +181,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}upper_wrist_link">
+      <material>Kortex/Gray</material>
+    </gazebo>
     <joint name="${prefix}joint_5" type="revolute">
       <origin xyz="0.0285 0 0.105" rpy="0 1.5708 0" />
       <parent link="${prefix}lower_wrist_link" />

--- a/kortex_description/arms/gen3_lite/6dof/urdf/gen3_lite_macro.xacro
+++ b/kortex_description/arms/gen3_lite/6dof/urdf/gen3_lite_macro.xacro
@@ -18,7 +18,7 @@
           <mesh filename="package://kortex_description/arms/gen3_lite/${dof}dof/meshes/base_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0.803 0.824 0.820 1" />
         </material>
       </visual>
       <collision>
@@ -43,7 +43,7 @@
           <mesh filename="package://kortex_description/arms/gen3_lite/${dof}dof/meshes/shoulder_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0.803 0.824 0.820 1" />
         </material>
       </visual>
       <collision>
@@ -75,7 +75,7 @@
           <mesh filename="package://kortex_description/arms/gen3_lite/${dof}dof/meshes/arm_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0.803 0.824 0.820 1" />
         </material>
       </visual>
       <collision>
@@ -107,7 +107,7 @@
           <mesh filename="package://kortex_description/arms/gen3_lite/${dof}dof/meshes/forearm_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0.803 0.824 0.820 1" />
         </material>
       </visual>
       <collision>
@@ -139,7 +139,7 @@
           <mesh filename="package://kortex_description/arms/gen3_lite/${dof}dof/meshes/lower_wrist_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0.803 0.824 0.820 1" />
         </material>
       </visual>
       <collision>
@@ -171,7 +171,7 @@
           <mesh filename="package://kortex_description/arms/gen3_lite/${dof}dof/meshes/upper_wrist_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0.803 0.824 0.820 1" />
         </material>
       </visual>
       <collision>

--- a/kortex_description/grippers/gen3_lite_2f/urdf/gen3_lite_2f_macro.xacro
+++ b/kortex_description/grippers/gen3_lite_2f/urdf/gen3_lite_2f_macro.xacro
@@ -22,7 +22,7 @@
           <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/gripper_base_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0.803 0.824 0.820 1" />
         </material>
       </visual>
       <collision>
@@ -48,7 +48,7 @@
         <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/right_finger_prox_link.STL" />
       </geometry>
       <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0.803 0.824 0.820 1" />
       </material>
     </visual>
     <collision>
@@ -59,7 +59,7 @@
     </collision>
     </link>
     <gazebo reference="${prefix}right_finger_prox_link">
-      <material>Gazebo/Black</material>
+      <material>Kortex/Gray</material>
     </gazebo>
     <joint name="${prefix}right_finger_bottom_joint" type="revolute">
       <origin xyz="0 -0.030501 0.070003" rpy="0 1.5708 0" />
@@ -80,7 +80,7 @@
           <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/right_finger_dist_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0 0.055 0.525 1" />
         </material>
       </visual>
       <collision>
@@ -114,7 +114,7 @@
           <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/left_finger_prox_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0.803 0.824 0.820 1" />
         </material>
       </visual>
       <collision>
@@ -125,7 +125,7 @@
       </collision>
     </link>
     <gazebo reference="${prefix}left_finger_prox_link">
-      <material>Gazebo/Black</material>
+      <material>Kortex/Gray</material>
     </gazebo>
     <joint name="${prefix}left_finger_bottom_joint" type="revolute">
       <origin xyz="0 0.0305 0.070003" rpy="0 1.5708 0" />
@@ -147,7 +147,7 @@
           <mesh filename="package://kortex_description/grippers/gen3_lite_2f/meshes/left_finger_dist_link.STL" />
         </geometry>
         <material name="">
-          <color rgba="0.75294 0.75294 0.75294 1" />
+          <color rgba="0 0.055 0.525 1" />
         </material>
       </visual>
       <collision>

--- a/kortex_description/grippers/gen3_lite_2f/urdf/gen3_lite_2f_macro.xacro
+++ b/kortex_description/grippers/gen3_lite_2f/urdf/gen3_lite_2f_macro.xacro
@@ -32,6 +32,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}gripper_base_link">
+      <material>Kortex/Gray</material>
+    </gazebo>
 
     <link name="${prefix}right_finger_prox_link">
     <inertial>
@@ -55,6 +58,9 @@
       </geometry>
     </collision>
     </link>
+    <gazebo reference="${prefix}right_finger_prox_link">
+      <material>Gazebo/Black</material>
+    </gazebo>
     <joint name="${prefix}right_finger_bottom_joint" type="revolute">
       <origin xyz="0 -0.030501 0.070003" rpy="0 1.5708 0" />
       <parent link="${prefix}gripper_base_link" />
@@ -84,6 +90,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}right_finger_dist_link">
+      <material>Kortex/Blue</material>
+    </gazebo>
     <joint name="${prefix}right_finger_tip_joint" type="revolute">
       <origin xyz="-0.045636 0.020423 0" rpy="0 0 0" />
       <parent link="${prefix}right_finger_prox_link" />
@@ -115,6 +124,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}left_finger_prox_link">
+      <material>Gazebo/Black</material>
+    </gazebo>
     <joint name="${prefix}left_finger_bottom_joint" type="revolute">
       <origin xyz="0 0.0305 0.070003" rpy="0 1.5708 0" />
       <parent link="${prefix}gripper_base_link" />
@@ -145,6 +157,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}left_finger_dist_link">
+      <material>Kortex/Blue</material>
+    </gazebo>
     <joint name="${prefix}left_finger_tip_joint" type="revolute">
       <origin xyz="-0.045636 -0.020423 6.9901E-05" rpy="0 0 0" />
       <parent link="${prefix}left_finger_prox_link" />

--- a/kortex_gazebo/media/materials/scripts/kortex.material
+++ b/kortex_gazebo/media/materials/scripts/kortex.material
@@ -1,0 +1,23 @@
+material Kortex/Gray
+{
+  technique
+  {
+    pass ambient
+    {
+      ambient 0.803 0.824 0.820
+      diffuse 0.803 0.824 0.820
+    }
+  }
+}
+
+material Kortex/Blue
+{
+  technique
+  {
+    pass ambient
+    {
+      ambient 0 0.055 0.525
+      diffuse 0 0.055 0.525
+    }
+  }
+}

--- a/kortex_gazebo/package.xml
+++ b/kortex_gazebo/package.xml
@@ -23,6 +23,7 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
   <export>
+    <gazebo_ros gazebo_media_path="${prefix}"/>
     <architecture_independent />
   </export>
 </package>


### PR DESCRIPTION
This PR adds infrastructure to easily add custom materials and textures for Gazebo.
I added colours for Gen3 lite simulation as a first pass, but we shall add more realistic textures soon.
![pico_gazebo_colours_only](https://user-images.githubusercontent.com/41082816/82376686-7574a180-99f0-11ea-9b13-76046b594c99.png)
