### PR TITLE
Fix Robotiq grippers flying around in pieces

### DIFF
--- a/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_transmission_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_2f_140_transmission_macro.xacro
@@ -21,6 +21,7 @@
                 <multiplier>-1.0</multiplier>
                 <offset>0.0</offset>
                 <maxEffort>5.0</maxEffort>
+                <hasPID/>
             </plugin>
             <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="mimic_robotiq_140_2">
                 <joint>finger_joint</joint>
@@ -28,6 +29,7 @@
                 <multiplier>-1.0</multiplier>
                 <offset>0.0</offset>
                 <maxEffort>5.0</maxEffort>
+                <hasPID/>
             </plugin>
             <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="mimic_robotiq_140_3">
                 <joint>finger_joint</joint>
@@ -35,6 +37,7 @@
                 <multiplier>-1.0</multiplier>
                 <offset>0.0</offset>
                 <maxEffort>5.0</maxEffort>
+                <hasPID/>
             </plugin>
             <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="mimic_robotiq_140_4">
                 <joint>finger_joint</joint>
@@ -42,6 +45,7 @@
                 <multiplier>1.0</multiplier>
                 <offset>0.0</offset>
                 <maxEffort>5.0</maxEffort>
+                <hasPID/>
             </plugin>
             <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="mimic_robotiq_140_5">
                 <joint>finger_joint</joint>
@@ -49,6 +53,7 @@
                 <multiplier>1.0</multiplier>
                 <offset>0.0</offset>
                 <maxEffort>5.0</maxEffort>
+                <hasPID/>
             </plugin>
 
             <plugin name="gazebo_grasp_fix" filename="libgazebo_grasp_fix.so">

--- a/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_arg2f.xacro
+++ b/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_arg2f.xacro
@@ -35,7 +35,7 @@
     </link>
 
     <gazebo reference="${prefix}robotiq_arg2f_base_link">
-      <material>Gazebo/Black</material>
+      <material>Gazebo/Black</material>  
     </gazebo>
 
   </xacro:macro>

--- a/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_arg2f_140_model_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_140/urdf/robotiq_arg2f_140_model_macro.xacro
@@ -29,6 +29,15 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}${fingerprefix}_outer_knuckle">
+      <visual>  
+        <material>  
+          <ambient>0.792156862745098 0.819607843137255 0.933333333333333 1</ambient>  
+          <diffuse>0.792156862745098 0.819607843137255 0.933333333333333 1</diffuse>  
+        </material>  
+      </visual> 
+    </gazebo>
+    
   </xacro:macro>
 
   <xacro:macro name="outer_finger" params="prefix fingerprefix stroke">
@@ -60,6 +69,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}${fingerprefix}_outer_finger">
+      <material>Gazebo/Black</material>
+    </gazebo>
   </xacro:macro>
 
   <xacro:macro name="inner_knuckle" params="prefix fingerprefix stroke">
@@ -91,6 +103,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}${fingerprefix}_inner_knuckle">
+      <material>Gazebo/Black</material>
+    </gazebo>
   </xacro:macro>
 
   <xacro:macro name="inner_finger" params="prefix fingerprefix stroke">
@@ -122,6 +137,9 @@
         </geometry>
       </collision>
     </link>
+    <gazebo reference="${prefix}${fingerprefix}_inner_finger">
+      <material>Gazebo/Black</material>
+    </gazebo>
   </xacro:macro>
 
   <!-- Finger pad link, the default are the "big pads" with rubber-->

--- a/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_transmission_macro.xacro
+++ b/kortex_description/grippers/robotiq_2f_85/urdf/robotiq_2f_85_transmission_macro.xacro
@@ -21,6 +21,7 @@
                 <multiplier>1.0</multiplier>
                 <offset>0.0</offset>
                 <maxEffort>5.0</maxEffort>
+                <hasPID/>
             </plugin>
             <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="mimic_robotiq_85_2">
                 <joint>finger_joint</joint>
@@ -28,6 +29,7 @@
                 <multiplier>1.0</multiplier>
                 <offset>0.0</offset>
                 <maxEffort>5.0</maxEffort>
+                <hasPID/>
             </plugin>
             <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="mimic_robotiq_85_3">
                 <joint>finger_joint</joint>
@@ -35,6 +37,7 @@
                 <multiplier>1.0</multiplier>
                 <offset>0.0</offset>
                 <maxEffort>5.0</maxEffort>
+                <hasPID/>
             </plugin>
             <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="mimic_robotiq_85_4">
                 <joint>finger_joint</joint>
@@ -42,6 +45,7 @@
                 <multiplier>-1.0</multiplier>
                 <offset>0.0</offset>
                 <maxEffort>5.0</maxEffort>
+                <hasPID/>
             </plugin>
             <plugin filename="libroboticsgroup_gazebo_mimic_joint_plugin.so" name="mimic_robotiq_85_5">
                 <joint>finger_joint</joint>
@@ -49,6 +53,7 @@
                 <multiplier>-1.0</multiplier>
                 <offset>0.0</offset>
                 <maxEffort>5.0</maxEffort>
+                <hasPID/>
             </plugin>
 
             <plugin name="gazebo_grasp_fix" filename="libgazebo_grasp_fix.so">

--- a/kortex_move_it_config/gen3_lite_gen3_lite_2f_move_it_config/config/kinematics.yaml
+++ b/kortex_move_it_config/gen3_lite_gen3_lite_2f_move_it_config/config/kinematics.yaml
@@ -2,4 +2,4 @@ arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3
+  

--- a/kortex_move_it_config/gen3_move_it_config/config/kinematics.yaml
+++ b/kortex_move_it_config/gen3_move_it_config/config/kinematics.yaml
@@ -2,4 +2,4 @@ arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3
+  

--- a/kortex_move_it_config/gen3_robotiq_2f_140_move_it_config/config/kinematics.yaml
+++ b/kortex_move_it_config/gen3_robotiq_2f_140_move_it_config/config/kinematics.yaml
@@ -2,4 +2,3 @@ arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3

--- a/kortex_move_it_config/gen3_robotiq_2f_85_move_it_config/config/kinematics.yaml
+++ b/kortex_move_it_config/gen3_robotiq_2f_85_move_it_config/config/kinematics.yaml
@@ -2,4 +2,3 @@ arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3


### PR DESCRIPTION
A misconfiguration in the mimic joint plugin would cause some chaos in the simulation for Robotiq grippers. Adding the <hasPID/> flag did the trick.
I also added a couple fixes for :
- A deprecation in MoveIt (Kinematic attempts)
- Some colour for the Robotiq 140

This was the gripper before the fix:

![before](https://user-images.githubusercontent.com/41082816/84090643-5dc18500-a9c0-11ea-93ad-cac21c0ab324.png)

This is the gripper after the fix:

![after](https://user-images.githubusercontent.com/41082816/84090656-67e38380-a9c0-11ea-824b-01544bddf6ab.png)

Addresses #89 