### PR TITLE
Fixing velocity control in simulation

### DIFF
--- a/kortex_driver/src/non-generated/driver/kortex_arm_simulation.cpp
+++ b/kortex_driver/src/non-generated/driver/kortex_arm_simulation.cpp
@@ -1283,15 +1283,15 @@ kortex_driver::KortexError KortexArmSimulation::ExecuteSendJointSpeeds(const kor
                 stopped[i] = false;
 
                 // Cap the command to the joint limit
-                if (m_arm_joint_limits_min[i] != 0.0 && commands[i] < 0.0)
+                if (m_arm_joint_limits_min[i] != 0.0 && commands[i] < m_arm_joint_limits_min[i])
                 {
-                    commands[i] = std::max(m_arm_joint_limits_min[i], commands[i]);
-                    velocity_command = 0.0;
+                    commands[i] = m_arm_joint_limits_min[i];
+                    velocity_command = std::max(velocity_command, 0.0);
                 }
-                else if (m_arm_joint_limits_max[i] != 0.0 && commands[i] > 0.0)
+                else if (m_arm_joint_limits_max[i] != 0.0 && commands[i] > m_arm_joint_limits_max[i])
                 {
-                    commands[i] = std::min(m_arm_joint_limits_max[i], commands[i]);
-                    velocity_command = 0.0;
+                    commands[i] = m_arm_joint_limits_max[i];
+                    velocity_command = std::min(velocity_command, 0.0);
                 }
 
                 // Send the position increments to the controllers


### PR DESCRIPTION
The kortex_driver was constantly setting the velocity_command variable and therefore the last velocity command to zero for all revolute joints. This commit fixes this and additionally lets the velocity variable drive the joint "away" from its limits. See issue #126 