### PR TITLE
Add kortex_control dependency to kortex_gazebo

### DIFF
--- a/kortex_gazebo/package.xml
+++ b/kortex_gazebo/package.xml
@@ -10,6 +10,7 @@
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>
+  <run_depend>kortex_control</run_depend>
   <run_depend>kortex_driver</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>rviz</run_depend>


### PR DESCRIPTION
I add `kortex_control` dependency to `kortex_gazebo`.

`kortex_control` is used in `kortex_gazebo`
https://github.com/Kinovarobotics/ros_kortex/blob/330c55bce8c3d463cca2492b3e0c89204f235640/kortex_gazebo/launch/spawn_kortex_robot.launch#L82-L85