### PR TITLE
Add prefix to ActionServer

### DIFF
--- a/kortex_driver/src/non-generated/driver/kortex_arm_driver.cpp
+++ b/kortex_driver/src/non-generated/driver/kortex_arm_driver.cpp
@@ -514,7 +514,7 @@ void KortexArmDriver::initRosServices()
 void KortexArmDriver::startActionServers()
 {
     // Start Action servers
-    m_action_server_follow_joint_trajectory = new JointTrajectoryActionServer(m_arm_name + "_joint_trajectory_controller/follow_joint_trajectory", m_node_handle, m_base, m_base_cyclic, m_control_config, m_use_hard_limits);
+    m_action_server_follow_joint_trajectory = new JointTrajectoryActionServer(m_prefix + m_arm_name + "_joint_trajectory_controller/follow_joint_trajectory", m_node_handle, m_base, m_base_cyclic, m_control_config, m_use_hard_limits);
     // Start Gripper Action Server if the arm has a gripper
     
     m_action_server_follow_cartesian_trajectory = new CartesianTrajectoryActionServer("cartesian_trajectory_controller/follow_cartesian_trajectory", m_node_handle, m_base, m_base_cyclic);
@@ -522,7 +522,7 @@ void KortexArmDriver::startActionServers()
     m_action_server_gripper_command = nullptr;
     if (isGripperPresent())
     {
-        m_action_server_gripper_command = new RobotiqGripperCommandActionServer(m_gripper_name + "_gripper_controller/gripper_cmd", m_gripper_joint_names[0], m_gripper_joint_limits_min[0], m_gripper_joint_limits_max[0], m_node_handle, m_base, m_base_cyclic);
+        m_action_server_gripper_command = new RobotiqGripperCommandActionServer(m_prefix + m_gripper_name + "_gripper_controller/gripper_cmd", m_gripper_joint_names[0], m_gripper_joint_limits_min[0], m_gripper_joint_limits_max[0], m_node_handle, m_base, m_base_cyclic);
     }
 }
 


### PR DESCRIPTION
When I use `prefix` arg in `kortex_driver.launch`, I get the following error.
To avoid this error, I add prefix to ActionServer name.
I am sorry that I checked this feature with [this commit](https://github.com/Kinovarobotics/ros_kortex/commit/996ffaffd33c135c6888ae624271aa2742fd83d4), not the latest version.

```
$ roslaunch kortex_driver kortex_driver.launch ip_address:=192.168.1.10 robot_name:=arm_gen3 start_rviz:=false arm:=gen3_lite gripper:=gen3_lite_2f vision:=false prefix:=kinova_
...
[ WARN] [1624531818.973946744]: Waiting for kinova_gen3_lite_joint_trajectory_controller/follow_joint_trajectory to come up
[ WARN] [1624531824.974310317]: Waiting for kinova_gen3_lite_joint_trajectory_controller/follow_joint_trajectory to come up
[ERROR] [1624531830.974661328]: Action client not connected: kinova_gen3_lite_joint_trajectory_controller/follow_joint_trajectory
[ WARN] [1624531836.027307069]: Waiting for kinova_gen3_lite_2f_gripper_controller/gripper_cmd to come up
[ WARN] [1624531842.027616054]: Waiting for kinova_gen3_lite_2f_gripper_controller/gripper_cmd to come up
[ERROR] [1624531848.027902299]: Action client not connected: kinova_gen3_lite_2f_gripper_controller/gripper_cmd
```

<details>
  <summary>All error logs</summary>
  
```
$ roslaunch kortex_driver kortex_driver.launch ip_address:=192.168.1.10 robot_name:=arm_gen3 start_rviz:=false arm:=gen3_lite gripper:=gen3_lite_2f vision:=false prefix:=kinova_
... logging to /home/yamaguchi/.ros/log/f2ce532c-d4d9-11eb-a562-d037458e7f3c/roslaunch-spot-jsk-21771.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
WARNING: disk usage in log directory [/home/yamaguchi/.ros/log] is over 1GB.
It's recommended that you use the 'rosclean' command.

xacro: in-order processing became default in ROS Melodic. You can drop the option.
xacro: in-order processing became default in ROS Melodic. You can drop the option.
started roslaunch server http://133.11.216.59:40715/

SUMMARY
========

PARAMETERS
 * /arm_gen3/arm_gen3_driver/api_connection_inactivity_timeout_ms: 20000
 * /arm_gen3/arm_gen3_driver/api_rpc_timeout_ms: 2000
 * /arm_gen3/arm_gen3_driver/api_session_inactivity_timeout_ms: 35000
 * /arm_gen3/arm_gen3_driver/arm: gen3_lite
 * /arm_gen3/arm_gen3_driver/cyclic_data_publish_rate: 40
 * /arm_gen3/arm_gen3_driver/default_goal_time_tolerance: 0.5
 * /arm_gen3/arm_gen3_driver/default_goal_tolerance: 0.005
 * /arm_gen3/arm_gen3_driver/dof: 6
 * /arm_gen3/arm_gen3_driver/gripper: gen3_lite_2f
 * /arm_gen3/arm_gen3_driver/gripper_joint_limits_max: [-0.09]
 * /arm_gen3/arm_gen3_driver/gripper_joint_limits_min: [0.96]
 * /arm_gen3/arm_gen3_driver/gripper_joint_names: ['kinova_right_fi...
 * /arm_gen3/arm_gen3_driver/ip_address: 192.168.1.10
 * /arm_gen3/arm_gen3_driver/joint_names: ['kinova_joint_1'...
 * /arm_gen3/arm_gen3_driver/maximum_accelerations: [1.0, 0.5, 0.4, 1...
 * /arm_gen3/arm_gen3_driver/maximum_velocities: [0.5, 0.5, 0.5, 0...
 * /arm_gen3/arm_gen3_driver/password: admin
 * /arm_gen3/arm_gen3_driver/prefix: kinova_
 * /arm_gen3/arm_gen3_driver/robot_name: arm_gen3
 * /arm_gen3/arm_gen3_driver/sim: False
 * /arm_gen3/arm_gen3_driver/use_hard_limits: False
 * /arm_gen3/arm_gen3_driver/username: admin
 * /arm_gen3/hztest_test_base_feedback/hz: 40
 * /arm_gen3/hztest_test_base_feedback/hzerror: 5.0
 * /arm_gen3/hztest_test_base_feedback/test_duration: 30.0
 * /arm_gen3/hztest_test_base_feedback/topic: base_feedback
 * /arm_gen3/hztest_test_base_feedback/wait_time: 10.0
 * /arm_gen3/hztest_test_driver_joint_state/hz: 40
 * /arm_gen3/hztest_test_driver_joint_state/hzerror: 5.0
 * /arm_gen3/hztest_test_driver_joint_state/test_duration: 30.0
 * /arm_gen3/hztest_test_driver_joint_state/topic: base_feedback/joi...
 * /arm_gen3/hztest_test_driver_joint_state/wait_time: 10.0
 * /arm_gen3/hztest_test_joint_state_publisher_joint_states/hz: 40
 * /arm_gen3/hztest_test_joint_state_publisher_joint_states/hzerror: 5.0
 * /arm_gen3/hztest_test_joint_state_publisher_joint_states/test_duration: 30.0
 * /arm_gen3/hztest_test_joint_state_publisher_joint_states/topic: joint_states
 * /arm_gen3/hztest_test_joint_state_publisher_joint_states/wait_time: 10.0
 * /arm_gen3/joint_state_publisher/rate: 40
 * /arm_gen3/joint_state_publisher/source_list: ['base_feedback/j...
 * /arm_gen3/joint_state_publisher/use_gui: False
 * /arm_gen3/kortex_driver_tests/api_connection_inactivity_timeout_ms: 20000
 * /arm_gen3/kortex_driver_tests/api_rpc_timeout_ms: 2000
 * /arm_gen3/kortex_driver_tests/api_session_inactivity_timeout_ms: 35000
 * /arm_gen3/kortex_driver_tests/arm: gen3_lite
 * /arm_gen3/kortex_driver_tests/cyclic_data_publish_rate: 40
 * /arm_gen3/kortex_driver_tests/default_goal_time_tolerance: 0.5
 * /arm_gen3/kortex_driver_tests/default_goal_tolerance: 0.005
 * /arm_gen3/kortex_driver_tests/dof: 6
 * /arm_gen3/kortex_driver_tests/gripper: gen3_lite_2f
 * /arm_gen3/kortex_driver_tests/gripper_joint_limits_max: [-0.09]
 * /arm_gen3/kortex_driver_tests/gripper_joint_limits_min: [0.96]
 * /arm_gen3/kortex_driver_tests/gripper_joint_names: ['kinova_right_fi...
 * /arm_gen3/kortex_driver_tests/ip_address: 192.168.1.10
 * /arm_gen3/kortex_driver_tests/joint_names: ['kinova_joint_1'...
 * /arm_gen3/kortex_driver_tests/maximum_accelerations: [1.0, 0.5, 0.4, 1...
 * /arm_gen3/kortex_driver_tests/maximum_velocities: [0.5, 0.5, 0.5, 0...
 * /arm_gen3/move_group/allow_trajectory_execution: True
 * /arm_gen3/move_group/arm/default_planner_config: RRTConnect
 * /arm_gen3/move_group/arm/longest_valid_segment_fraction: 0.005
 * /arm_gen3/move_group/arm/planner_configs: ['SBL', 'EST', 'L...
 * /arm_gen3/move_group/arm/projection_evaluator: joints(kinova_joi...
 * /arm_gen3/move_group/capabilities:
 * /arm_gen3/move_group/controller_list: [{'default': True...
 * /arm_gen3/move_group/disable_capabilities:
 * /arm_gen3/move_group/gripper/default_planner_config: RRTConnect
 * /arm_gen3/move_group/gripper/planner_configs: ['SBL', 'EST', 'L...
 * /arm_gen3/move_group/jiggle_fraction: 0.05
 * /arm_gen3/move_group/joint_state_controller/publish_rate: 50
 * /arm_gen3/move_group/joint_state_controller/type: joint_state_contr...
 * /arm_gen3/move_group/max_safe_path_cost: 1
 * /arm_gen3/move_group/moveit_controller_manager: moveit_simple_con...
 * /arm_gen3/move_group/moveit_manage_controllers: True
 * /arm_gen3/move_group/planner_configs/BFMT/balanced: 0
 * /arm_gen3/move_group/planner_configs/BFMT/cache_cc: 1
 * /arm_gen3/move_group/planner_configs/BFMT/extended_fmt: 1
 * /arm_gen3/move_group/planner_configs/BFMT/heuristics: 1
 * /arm_gen3/move_group/planner_configs/BFMT/nearest_k: 1
 * /arm_gen3/move_group/planner_configs/BFMT/num_samples: 1000
 * /arm_gen3/move_group/planner_configs/BFMT/optimality: 1
 * /arm_gen3/move_group/planner_configs/BFMT/radius_multiplier: 1.0
 * /arm_gen3/move_group/planner_configs/BFMT/type: geometric::BFMT
 * /arm_gen3/move_group/planner_configs/BKPIECE/border_fraction: 0.9
 * /arm_gen3/move_group/planner_configs/BKPIECE/failed_expansion_score_factor: 0.5
 * /arm_gen3/move_group/planner_configs/BKPIECE/min_valid_path_fraction: 0.5
 * /arm_gen3/move_group/planner_configs/BKPIECE/range: 0.0
 * /arm_gen3/move_group/planner_configs/BKPIECE/type: geometric::BKPIECE
 * /arm_gen3/move_group/planner_configs/BiEST/range: 0.0
 * /arm_gen3/move_group/planner_configs/BiEST/type: geometric::BiEST
 * /arm_gen3/move_group/planner_configs/BiTRRT/cost_threshold: 1e300
 * /arm_gen3/move_group/planner_configs/BiTRRT/frountier_node_ratio: 0.1
 * /arm_gen3/move_group/planner_configs/BiTRRT/frountier_threshold: 0.0
 * /arm_gen3/move_group/planner_configs/BiTRRT/init_temperature: 100
 * /arm_gen3/move_group/planner_configs/BiTRRT/range: 0.0
 * /arm_gen3/move_group/planner_configs/BiTRRT/temp_change_factor: 0.1
 * /arm_gen3/move_group/planner_configs/BiTRRT/type: geometric::BiTRRT
 * /arm_gen3/move_group/planner_configs/EST/goal_bias: 0.05
 * /arm_gen3/move_group/planner_configs/EST/range: 0.0
 * /arm_gen3/move_group/planner_configs/EST/type: geometric::EST
 * /arm_gen3/move_group/planner_configs/FMT/cache_cc: 1
 * /arm_gen3/move_group/planner_configs/FMT/extended_fmt: 1
 * /arm_gen3/move_group/planner_configs/FMT/heuristics: 0
 * /arm_gen3/move_group/planner_configs/FMT/nearest_k: 1
 * /arm_gen3/move_group/planner_configs/FMT/num_samples: 1000
 * /arm_gen3/move_group/planner_configs/FMT/radius_multiplier: 1.1
 * /arm_gen3/move_group/planner_configs/FMT/type: geometric::FMT
 * /arm_gen3/move_group/planner_configs/KPIECE/border_fraction: 0.9
 * /arm_gen3/move_group/planner_configs/KPIECE/failed_expansion_score_factor: 0.5
 * /arm_gen3/move_group/planner_configs/KPIECE/goal_bias: 0.05
 * /arm_gen3/move_group/planner_configs/KPIECE/min_valid_path_fraction: 0.5
 * /arm_gen3/move_group/planner_configs/KPIECE/range: 0.0
 * /arm_gen3/move_group/planner_configs/KPIECE/type: geometric::KPIECE
 * /arm_gen3/move_group/planner_configs/LBKPIECE/border_fraction: 0.9
 * /arm_gen3/move_group/planner_configs/LBKPIECE/min_valid_path_fraction: 0.5
 * /arm_gen3/move_group/planner_configs/LBKPIECE/range: 0.0
 * /arm_gen3/move_group/planner_configs/LBKPIECE/type: geometric::LBKPIECE
 * /arm_gen3/move_group/planner_configs/LBTRRT/epsilon: 0.4
 * /arm_gen3/move_group/planner_configs/LBTRRT/goal_bias: 0.05
 * /arm_gen3/move_group/planner_configs/LBTRRT/range: 0.0
 * /arm_gen3/move_group/planner_configs/LBTRRT/type: geometric::LBTRRT
 * /arm_gen3/move_group/planner_configs/LazyPRM/range: 0.0
 * /arm_gen3/move_group/planner_configs/LazyPRM/type: geometric::LazyPRM
 * /arm_gen3/move_group/planner_configs/LazyPRMstar/type: geometric::LazyPR...
 * /arm_gen3/move_group/planner_configs/PDST/type: geometric::PDST
 * /arm_gen3/move_group/planner_configs/PRM/max_nearest_neighbors: 10
 * /arm_gen3/move_group/planner_configs/PRM/type: geometric::PRM
 * /arm_gen3/move_group/planner_configs/PRMstar/type: geometric::PRMstar
 * /arm_gen3/move_group/planner_configs/ProjEST/goal_bias: 0.05
 * /arm_gen3/move_group/planner_configs/ProjEST/range: 0.0
 * /arm_gen3/move_group/planner_configs/ProjEST/type: geometric::ProjEST
 * /arm_gen3/move_group/planner_configs/RRT/goal_bias: 0.05
 * /arm_gen3/move_group/planner_configs/RRT/range: 0.0
 * /arm_gen3/move_group/planner_configs/RRT/type: geometric::RRT
 * /arm_gen3/move_group/planner_configs/RRTConnect/range: 0.0
 * /arm_gen3/move_group/planner_configs/RRTConnect/type: geometric::RRTCon...
 * /arm_gen3/move_group/planner_configs/RRTstar/delay_collision_checking: 1
 * /arm_gen3/move_group/planner_configs/RRTstar/goal_bias: 0.05
 * /arm_gen3/move_group/planner_configs/RRTstar/range: 0.0
 * /arm_gen3/move_group/planner_configs/RRTstar/type: geometric::RRTstar
 * /arm_gen3/move_group/planner_configs/SBL/range: 0.0
 * /arm_gen3/move_group/planner_configs/SBL/type: geometric::SBL
 * /arm_gen3/move_group/planner_configs/SPARS/dense_delta_fraction: 0.001
 * /arm_gen3/move_group/planner_configs/SPARS/max_failures: 1000
 * /arm_gen3/move_group/planner_configs/SPARS/sparse_delta_fraction: 0.25
 * /arm_gen3/move_group/planner_configs/SPARS/stretch_factor: 3.0
 * /arm_gen3/move_group/planner_configs/SPARS/type: geometric::SPARS
 * /arm_gen3/move_group/planner_configs/SPARStwo/dense_delta_fraction: 0.001
 * /arm_gen3/move_group/planner_configs/SPARStwo/max_failures: 5000
 * /arm_gen3/move_group/planner_configs/SPARStwo/sparse_delta_fraction: 0.25
 * /arm_gen3/move_group/planner_configs/SPARStwo/stretch_factor: 3.0
 * /arm_gen3/move_group/planner_configs/SPARStwo/type: geometric::SPARStwo
 * /arm_gen3/move_group/planner_configs/STRIDE/degree: 16
 * /arm_gen3/move_group/planner_configs/STRIDE/estimated_dimension: 0.0
 * /arm_gen3/move_group/planner_configs/STRIDE/goal_bias: 0.05
 * /arm_gen3/move_group/planner_configs/STRIDE/max_degree: 18
 * /arm_gen3/move_group/planner_configs/STRIDE/max_pts_per_leaf: 6
 * /arm_gen3/move_group/planner_configs/STRIDE/min_degree: 12
 * /arm_gen3/move_group/planner_configs/STRIDE/min_valid_path_fraction: 0.2
 * /arm_gen3/move_group/planner_configs/STRIDE/range: 0.0
 * /arm_gen3/move_group/planner_configs/STRIDE/type: geometric::STRIDE
 * /arm_gen3/move_group/planner_configs/STRIDE/use_projected_distance: 0
 * /arm_gen3/move_group/planner_configs/TRRT/frountierNodeRatio: 0.1
 * /arm_gen3/move_group/planner_configs/TRRT/frountier_threshold: 0.0
 * /arm_gen3/move_group/planner_configs/TRRT/goal_bias: 0.05
 * /arm_gen3/move_group/planner_configs/TRRT/init_temperature: 10e-6
 * /arm_gen3/move_group/planner_configs/TRRT/k_constant: 0.0
 * /arm_gen3/move_group/planner_configs/TRRT/max_states_failed: 10
 * /arm_gen3/move_group/planner_configs/TRRT/min_temperature: 10e-10
 * /arm_gen3/move_group/planner_configs/TRRT/range: 0.0
 * /arm_gen3/move_group/planner_configs/TRRT/temp_change_factor: 2.0
 * /arm_gen3/move_group/planner_configs/TRRT/type: geometric::TRRT
 * /arm_gen3/move_group/planning_plugin: ompl_interface/OM...
 * /arm_gen3/move_group/planning_scene_monitor/publish_geometry_updates: True
 * /arm_gen3/move_group/planning_scene_monitor/publish_planning_scene: True
 * /arm_gen3/move_group/planning_scene_monitor/publish_state_updates: True
 * /arm_gen3/move_group/planning_scene_monitor/publish_transforms_updates: True
 * /arm_gen3/move_group/request_adapters: industrial_trajec...
 * /arm_gen3/move_group/sample_duration: 0.001
 * /arm_gen3/move_group/start_state_max_bounds_error: 0.1
 * /arm_gen3/move_group/trajectory_execution/allowed_execution_duration_scaling: 1.2
 * /arm_gen3/move_group/trajectory_execution/allowed_goal_duration_margin: 2.0
 * /arm_gen3/move_group/trajectory_execution/allowed_start_tolerance: 0.01
 * /arm_gen3/publish_test_kortex_driver/topics: [{'name': '/arm_g...
 * /arm_gen3/robot_description: <?xml version="1....
 * /arm_gen3/robot_description_kinematics/arm/kinematics_solver: kdl_kinematics_pl...
 * /arm_gen3/robot_description_kinematics/arm/kinematics_solver_search_resolution: 0.005
 * /arm_gen3/robot_description_kinematics/arm/kinematics_solver_timeout: 0.005
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_1/has_acceleration_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_1/has_velocity_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_1/max_acceleration: 0.35
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_1/max_velocity: 0.99
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_2/has_acceleration_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_2/has_velocity_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_2/max_acceleration: 0.17
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_2/max_velocity: 0.99
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_3/has_acceleration_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_3/has_velocity_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_3/max_acceleration: 0.14
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_3/max_velocity: 0.99
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_4/has_acceleration_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_4/has_velocity_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_4/max_acceleration: 0.35
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_4/max_velocity: 0.99
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_5/has_acceleration_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_5/has_velocity_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_5/max_acceleration: 3.5
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_5/max_velocity: 0.99
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_6/has_acceleration_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_6/has_velocity_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_6/max_acceleration: 3.5
 * /arm_gen3/robot_description_planning/joint_limits/kinova_joint_6/max_velocity: 1.55
 * /arm_gen3/robot_description_planning/joint_limits/right_finger_bottom_joint/has_acceleration_limits: False
 * /arm_gen3/robot_description_planning/joint_limits/right_finger_bottom_joint/has_velocity_limits: True
 * /arm_gen3/robot_description_planning/joint_limits/right_finger_bottom_joint/max_acceleration: 0
 * /arm_gen3/robot_description_planning/joint_limits/right_finger_bottom_joint/max_velocity: 1000
 * /arm_gen3/robot_description_semantic: <?xml version="1....
 * /rosdistro: melodic
 * /rosversion: 1.14.11

NODES
  /arm_gen3/
    arm_gen3_driver (kortex_driver/kortex_arm_driver)
    joint_state_publisher (joint_state_publisher/joint_state_publisher)
    move_group (moveit_ros_move_group/move_group)
    robot_state_publisher (robot_state_publisher/robot_state_publisher)

auto-starting new master
process[master]: started with pid [21787]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to f2ce532c-d4d9-11eb-a562-d037458e7f3c
process[rosout-1]: started with pid [21798]
started core service [/rosout]
process[arm_gen3/arm_gen3_driver-2]: started with pid [21805]
process[arm_gen3/move_group-3]: started with pid [21806]
process[arm_gen3/joint_state_publisher-4]: started with pid [21807]
process[arm_gen3/robot_state_publisher-5]: started with pid [21808]
[ WARN] [1624531812.604147865]: The root link kinova_base_link has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
[ INFO] [1624531812.621614513]: Loading robot model 'gen3_lite_gen3_lite_2f'...
[ INFO] [1624531812.622362772]: No root/virtual joint specified in SRDF. Assuming fixed joint
[ INFO] [1624531812.679136168]: Session created successfully for TCP services
[ INFO] [1624531812.689551475]: Session created successfully for UDP services
[ INFO] [1624531812.693264056]: -------------------------------------------------
[ INFO] [1624531812.693283802]: Scanning all devices in robot...
[ INFO] [1624531812.718259900]: Base device was found on device identifier 0
[ INFO] [1624531812.718637383]: Actuator device of type SMALL_ACTUATOR was found on device identifier 7
[ INFO] [1624531812.718652127]: Actuator device of type SMALL_ACTUATOR was found on device identifier 5
[ INFO] [1624531812.718659685]: Actuator device of type MEDIUM_ACTUATOR was found on device identifier 1
[ INFO] [1624531812.718666473]: Actuator device of type BIG_ACTUATOR was found on device identifier 2
[ INFO] [1624531812.718673057]: Actuator device of type MEDIUM_ACTUATOR was found on device identifier 3
[ INFO] [1624531812.718679800]: Actuator device of type SMALL_ACTUATOR was found on device identifier 4
[ INFO] [1624531812.718687131]: -------------------------------------------------
[ INFO] [1624531812.748651781]: State changed from INITIALIZING to IDLE

[ INFO] [1624531812.752499001]: -------------------------------------------------
[ INFO] [1624531812.752514691]: Initializing Kortex Driver's services...
[ WARN] [1624531812.795033510]: Could not identify parent group for end-effector 'end_effector'
[ WARN] [1624531812.826119138]: The root link kinova_base_link has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
[ INFO] [1624531813.418450724]: Publishing maintained planning scene on 'monitored_planning_scene'
[ INFO] [1624531813.419955177]: MoveGroup debug mode is OFF
Starting planning scene monitors...
[ INFO] [1624531813.419974287]: Starting planning scene monitor
[ INFO] [1624531813.421583605]: Listening to '/arm_gen3/planning_scene'
[ INFO] [1624531813.421601771]: Starting world geometry update monitor for collision objects, attached objects, octomap updates.
[ INFO] [1624531813.422686672]: Listening to '/arm_gen3/collision_object'
[ INFO] [1624531813.423768783]: Listening to '/arm_gen3/planning_scene_world' for planning scene world geometry
[ WARN] [1624531813.423975200]: Resolution not specified for Octomap. Assuming resolution = 0.1 instead
[ INFO] [1624531813.424172081]: No 3D sensor plugin(s) defined for octomap updates
[ INFO] [1624531813.928778724]: Listening to '/arm_gen3/attached_collision_object' for attached collision objects
Planning scene monitors started.
[ INFO] [1624531813.945712562]: Initializing OMPL interface using ROS parameters
[ INFO] [1624531813.962140468]: Using planning interface 'OMPL'
[ INFO] [1624531813.963537188]: Constructing N point filter
[ INFO] [1624531813.964646606]: Param 'default_workspace_bounds' was not set. Using default value: 10
[ INFO] [1624531813.964859498]: Param 'start_state_max_bounds_error' was set to 0.1
[ INFO] [1624531813.965044937]: Param 'start_state_max_dt' was not set. Using default value: 0.5
[ INFO] [1624531813.965245293]: Param 'start_state_max_dt' was not set. Using default value: 0.5
[ INFO] [1624531813.965425875]: Param 'jiggle_fraction' was set to 0.05
[ INFO] [1624531813.965605261]: Param 'max_sampling_attempts' was not set. Using default value: 100
[ INFO] [1624531813.965634048]: Using planning request adapter 'Trajectory filter 'UniformSampleFilter' of type 'UniformSampleFilter''
[ INFO] [1624531813.965643717]: Using planning request adapter 'Add Time Parameterization'
[ INFO] [1624531813.965653021]: Using planning request adapter 'Fix Workspace Bounds'
[ INFO] [1624531813.965661427]: Using planning request adapter 'Fix Start State Bounds'
[ INFO] [1624531813.965669973]: Using planning request adapter 'Fix Start State In Collision'
[ INFO] [1624531813.965676404]: Using planning request adapter 'Fix Start State Path Constraints'
[ INFO] [1624531814.842475369]: Kortex Driver's services initialized correctly.
[ INFO] [1624531814.842571397]: -------------------------------------------------
[ INFO] [1624531814.845798847]: The Kortex driver has been initialized correctly!
[ WARN] [1624531818.973946744]: Waiting for kinova_gen3_lite_joint_trajectory_controller/follow_joint_trajectory to come up
[ WARN] [1624531824.974310317]: Waiting for kinova_gen3_lite_joint_trajectory_controller/follow_joint_trajectory to come up
[ERROR] [1624531830.974661328]: Action client not connected: kinova_gen3_lite_joint_trajectory_controller/follow_joint_trajectory
[ WARN] [1624531836.027307069]: Waiting for kinova_gen3_lite_2f_gripper_controller/gripper_cmd to come up
[ WARN] [1624531842.027616054]: Waiting for kinova_gen3_lite_2f_gripper_controller/gripper_cmd to come up
[ERROR] [1624531848.027902299]: Action client not connected: kinova_gen3_lite_2f_gripper_controller/gripper_cmd
[ INFO] [1624531848.135361275]: Returned 0 controllers in list
[ INFO] [1624531848.169197020]: Trajectory execution is managing controllers
Loading 'move_group/ApplyPlanningSceneService'...
Loading 'move_group/ClearOctomapService'...
Loading 'move_group/MoveGroupCartesianPathService'...
Loading 'move_group/MoveGroupExecuteTrajectoryAction'...
Loading 'move_group/MoveGroupGetPlanningSceneService'...
Loading 'move_group/MoveGroupKinematicsService'...
Loading 'move_group/MoveGroupMoveAction'...
Loading 'move_group/MoveGroupPickPlaceAction'...
Loading 'move_group/MoveGroupPlanService'...
Loading 'move_group/MoveGroupQueryPlannersService'...
Loading 'move_group/MoveGroupStateValidationService'...
[ INFO] [1624531848.230641205]:

********************************************************
* MoveGroup using:
*     - ApplyPlanningSceneService
*     - ClearOctomapService
*     - CartesianPathService
*     - ExecuteTrajectoryAction
*     - GetPlanningSceneService
*     - KinematicsService
*     - MoveAction
*     - PickPlaceAction
*     - MotionPlanService
*     - QueryPlannersService
*     - StateValidationService
********************************************************

[ INFO] [1624531848.230689396]: MoveGroup context using planning plugin ompl_interface/OMPLPlanner
[ INFO] [1624531848.230707223]: MoveGroup context initialization complete

You can start planning now!
```
</details>

cc @tkmtnt7000
