### PR TITLE
missing prefix in driver

### DIFF
--- a/kortex_driver/src/non-generated/driver/kortex_arm_driver.cpp
+++ b/kortex_driver/src/non-generated/driver/kortex_arm_driver.cpp
@@ -514,7 +514,7 @@ void KortexArmDriver::initRosServices()
 void KortexArmDriver::startActionServers()
 {
     // Start Action servers
-    m_action_server_follow_joint_trajectory = new JointTrajectoryActionServer(m_arm_name + "_joint_trajectory_controller/follow_joint_trajectory", m_node_handle, m_base, m_base_cyclic, m_control_config, m_use_hard_limits);
+    m_action_server_follow_joint_trajectory = new JointTrajectoryActionServer(m_prefix + m_arm_name + "_joint_trajectory_controller/follow_joint_trajectory", m_node_handle, m_base, m_base_cyclic, m_control_config, m_use_hard_limits);
     // Start Gripper Action Server if the arm has a gripper
     
     m_action_server_follow_cartesian_trajectory = new CartesianTrajectoryActionServer("cartesian_trajectory_controller/follow_cartesian_trajectory", m_node_handle, m_base, m_base_cyclic);
@@ -522,7 +522,7 @@ void KortexArmDriver::startActionServers()
     m_action_server_gripper_command = nullptr;
     if (isGripperPresent())
     {
-        m_action_server_gripper_command = new RobotiqGripperCommandActionServer(m_gripper_name + "_gripper_controller/gripper_cmd", m_gripper_joint_names[0], m_gripper_joint_limits_min[0], m_gripper_joint_limits_max[0], m_node_handle, m_base, m_base_cyclic);
+        m_action_server_gripper_command = new RobotiqGripperCommandActionServer(m_prefix + m_gripper_name + "_gripper_controller/gripper_cmd", m_gripper_joint_names[0], m_gripper_joint_limits_min[0], m_gripper_joint_limits_max[0], m_node_handle, m_base, m_base_cyclic);
     }
 }
 

--- a/kortex_driver/src/non-generated/driver/kortex_arm_simulation.cpp
+++ b/kortex_driver/src/non-generated/driver/kortex_arm_simulation.cpp
@@ -588,7 +588,7 @@ void KortexArmSimulation::CreateDefaultActions()
         kortex_driver::JointAngle a;
         a.joint_identifier = i;
         auto named_target = m_moveit_arm_interface->getNamedTargetValues("retract");
-        double moveit_angle = named_target["joint_"+std::to_string(i+1)]; // rad
+        double moveit_angle = named_target[m_prefix + "joint_"+std::to_string(i+1)]; // rad
         a.value = m_math_util.wrapDegreesFromZeroTo360(m_math_util.toDeg(moveit_angle));
         retract_angles.joint_angles.joint_angles.push_back(a);
     }
@@ -603,7 +603,7 @@ void KortexArmSimulation::CreateDefaultActions()
         kortex_driver::JointAngle a;
         a.joint_identifier = i;
         auto named_target = m_moveit_arm_interface->getNamedTargetValues("home");
-        double moveit_angle = named_target["joint_"+std::to_string(i+1)]; // rad
+        double moveit_angle = named_target[m_prefix + "joint_"+std::to_string(i+1)]; // rad
         a.value = m_math_util.wrapDegreesFromZeroTo360(m_math_util.toDeg(moveit_angle));
         home_angles.joint_angles.joint_angles.push_back(a);
     }
@@ -618,7 +618,7 @@ void KortexArmSimulation::CreateDefaultActions()
         kortex_driver::JointAngle a;
         a.joint_identifier = i;
         auto named_target = m_moveit_arm_interface->getNamedTargetValues("vertical");
-        double moveit_angle = named_target["joint_"+std::to_string(i+1)]; // rad
+        double moveit_angle = named_target[m_prefix + "joint_"+std::to_string(i+1)]; // rad
         a.value = m_math_util.wrapDegreesFromZeroTo360(m_math_util.toDeg(moveit_angle));
         zero_angles.joint_angles.joint_angles.push_back(a);
     }


### PR DESCRIPTION
modifications in kortex_arm_driver.cpp following this PR : https://github.com/Kinovarobotics/ros_kortex/pull/162

modifications in kortex_arm_simulation.cpp because presets in MoveIt! were returning 0 as value for each joint (because looking at the wrong topic)