### PR TITLE
Update deprecated service

### DIFF
--- a/kortex_examples/src/full_arm/example_cartesian_poses_with_notifications.cpp
+++ b/kortex_examples/src/full_arm/example_cartesian_poses_with_notifications.cpp
@@ -14,12 +14,10 @@
 
 #include "ros/ros.h"
 #include <kortex_driver/Base_ClearFaults.h>
-#include <kortex_driver/PlayCartesianTrajectory.h>
 #include <kortex_driver/CartesianSpeed.h>
 #include <kortex_driver/BaseCyclic_Feedback.h>
 #include <kortex_driver/ReadAction.h>
 #include <kortex_driver/ExecuteAction.h>
-#include <kortex_driver/PlayJointTrajectory.h>
 #include <kortex_driver/SetCartesianReferenceFrame.h>
 #include <kortex_driver/CartesianReferenceFrame.h>
 #include <kortex_driver/SendGripperCommand.h>

--- a/kortex_examples/src/full_arm/example_full_arm_movement.cpp
+++ b/kortex_examples/src/full_arm/example_full_arm_movement.cpp
@@ -215,7 +215,7 @@ bool example_send_joint_angles(ros::NodeHandle n, const std::string &robot_name,
   }
 
   // Each AngularWaypoint needs a duration and the global duration (from WaypointList) is disregarded. 
-  // If you somehting too small (for either global duration or AngularWaypoint duration), the trajectory will be rejected.
+  // If you put something too small (for either global duration or AngularWaypoint duration), the trajectory will be rejected.
   int angular_duration = 0;
   angularWaypoint.duration = angular_duration;
 

--- a/kortex_examples/src/full_arm/example_full_arm_movement.cpp
+++ b/kortex_examples/src/full_arm/example_full_arm_movement.cpp
@@ -215,7 +215,6 @@ bool example_send_joint_angles(ros::NodeHandle n, const std::string &robot_name,
   }
 
   // Each AngularWaypoint needs a duration and the global duration (from WaypointList) is disregarded. 
-  // If you put 0 to the global duration, the trajectory will be optimal.
   // If you somehting too small (for either global duration or AngularWaypoint duration), the trajectory will be rejected.
   int angular_duration = 0;
   angularWaypoint.duration = angular_duration;

--- a/kortex_examples/src/full_arm/example_full_arm_movement.py
+++ b/kortex_examples/src/full_arm/example_full_arm_movement.py
@@ -224,7 +224,6 @@ class ExampleFullArmMovement:
             angularWaypoint.angles.append(0.0)
 
         # Each AngularWaypoint needs a duration and the global duration (from WaypointList) is disregarded. 
-        # If you put 0 to the global duration, the trajectory will be optimal.
         # If you somehting too small (for either global duration or AngularWaypoint duration), the trajectory will be rejected.
         angular_duration = 0
         angularWaypoint.duration = angular_duration

--- a/kortex_examples/src/full_arm/example_full_arm_movement.py
+++ b/kortex_examples/src/full_arm/example_full_arm_movement.py
@@ -224,7 +224,7 @@ class ExampleFullArmMovement:
             angularWaypoint.angles.append(0.0)
 
         # Each AngularWaypoint needs a duration and the global duration (from WaypointList) is disregarded. 
-        # If you somehting too small (for either global duration or AngularWaypoint duration), the trajectory will be rejected.
+        # If you put something too small (for either global duration or AngularWaypoint duration), the trajectory will be rejected.
         angular_duration = 0
         angularWaypoint.duration = angular_duration
 

--- a/kortex_examples/src/full_arm/example_full_arm_movement.py
+++ b/kortex_examples/src/full_arm/example_full_arm_movement.py
@@ -54,14 +54,6 @@ class ExampleFullArmMovement:
             rospy.wait_for_service(set_cartesian_reference_frame_full_name)
             self.set_cartesian_reference_frame = rospy.ServiceProxy(set_cartesian_reference_frame_full_name, SetCartesianReferenceFrame)
 
-            play_cartesian_trajectory_full_name = '/' + self.robot_name + '/base/play_cartesian_trajectory'
-            rospy.wait_for_service(play_cartesian_trajectory_full_name)
-            self.play_cartesian_trajectory = rospy.ServiceProxy(play_cartesian_trajectory_full_name, PlayCartesianTrajectory)
-
-            play_joint_trajectory_full_name = '/' + self.robot_name + '/base/play_joint_trajectory'
-            rospy.wait_for_service(play_joint_trajectory_full_name)
-            self.play_joint_trajectory = rospy.ServiceProxy(play_joint_trajectory_full_name, PlayJointTrajectory)
-
             send_gripper_command_full_name = '/' + self.robot_name + '/base/send_gripper_command'
             rospy.wait_for_service(send_gripper_command_full_name)
             self.send_gripper_command = rospy.ServiceProxy(send_gripper_command_full_name, SendGripperCommand)
@@ -184,28 +176,32 @@ class ExampleFullArmMovement:
         # Here we only need the latest message in the topic though
         feedback = rospy.wait_for_message("/" + self.robot_name + "/base_feedback", BaseCyclic_Feedback)
 
-        req = PlayCartesianTrajectoryRequest()
-        req.input.target_pose.x = feedback.base.commanded_tool_pose_x
-        req.input.target_pose.y = feedback.base.commanded_tool_pose_y
-        req.input.target_pose.z = feedback.base.commanded_tool_pose_z + 0.10
-        req.input.target_pose.theta_x = feedback.base.commanded_tool_pose_theta_x
-        req.input.target_pose.theta_y = feedback.base.commanded_tool_pose_theta_y
-        req.input.target_pose.theta_z = feedback.base.commanded_tool_pose_theta_z
+        # Possible to execute waypointList via execute_action service or use execute_waypoint_trajectory service directly
+        req = ExecuteActionRequest()
+        trajectory = WaypointList()
 
-        pose_speed = CartesianSpeed()
-        pose_speed.translation = 0.1
-        pose_speed.orientation = 15
+        trajectory.waypoints.append(
+            self.FillCartesianWaypoint(
+                feedback.base.commanded_tool_pose_x,
+                feedback.base.commanded_tool_pose_y,
+                feedback.base.commanded_tool_pose_z + 0.10,
+                feedback.base.commanded_tool_pose_theta_x,
+                feedback.base.commanded_tool_pose_theta_y,
+                feedback.base.commanded_tool_pose_theta_z,
+                0)
+        )
 
-        # The constraint is a one_of in Protobuf. The one_of concept does not exist in ROS
-        # To specify a one_of, create it and put it in the appropriate list of the oneof_type member of the ROS object : 
-        req.input.constraint.oneof_type.speed.append(pose_speed)
+        trajectory.duration = 0
+        trajectory.use_optimal_blending = 0
+
+        req.input.oneof_action_parameters.execute_waypoint_list.append(trajectory)
 
         # Call the service
         rospy.loginfo("Sending the robot to the cartesian pose...")
         try:
-            self.play_cartesian_trajectory(req)
+            self.execute_action(req)
         except rospy.ServiceException:
-            rospy.logerr("Failed to call PlayCartesianTrajectory")
+            rospy.logerr("Failed to call ExecuteWaypointTrajectory")
             return False
         else:
             return self.wait_for_action_end_or_abort()
@@ -213,20 +209,31 @@ class ExampleFullArmMovement:
     def example_send_joint_angles(self):
         self.last_action_notif_type = None
         # Create the list of angles
-        req = PlayJointTrajectoryRequest()
+        req = ExecuteActionRequest()
+        trajectory = WaypointList()
+
+        waypoint = Waypoint()
+        angularWaypoint = AngularWaypoint()
+
         # Here the arm is vertical (all zeros)
-        for i in range(self.degrees_of_freedom):
-            temp_angle = JointAngle() 
-            temp_angle.joint_identifier = i
-            temp_angle.value = 0.0
-            req.input.joint_angles.joint_angles.append(temp_angle)
+        for _ in range(self.degrees_of_freedom):
+            angularWaypoint.angles.append(0.0)
+
+        angularWaypoint.duration = 20 # Arbitrary 20s to reach position
+        waypoint.oneof_type_of_waypoint.angular_waypoint.append(angularWaypoint)
+
+        trajectory.waypoints.append(waypoint)
+        trajectory.duration = 0
+        trajectory.use_optimal_blending = 0
+
+        req.input.oneof_action_parameters.execute_waypoint_list.append(trajectory)
         
         # Send the angles
         rospy.loginfo("Sending the robot vertical...")
         try:
-            self.play_joint_trajectory(req)
+            self.execute_action(req)
         except rospy.ServiceException:
-            rospy.logerr("Failed to call PlayJointTrajectory")
+            rospy.logerr("Failed to call ExecuteWaypointjectory")
             return False
         else:
             return self.wait_for_action_end_or_abort()

--- a/kortex_gazebo/readme.md
+++ b/kortex_gazebo/readme.md
@@ -47,7 +47,7 @@ The launch can be parametrized with arguments :
 - **y0** : The default Y-axis position of the robot in Gazebo. The default value is **0.0**.
 - **z0** : The default Z-axis position of the robot in Gazebo. The default value is **0.0**.
 - **arm** : Name of your robot arm model. See the `kortex_description/arms` folder to see the available robot models. The default value is **gen3**.
-- **gripper** : Name of your robot arm's tool / gripper. See the `kortex_description/grippers` folder to see the available end effector models (or to add your own). The default value is **""**. For Gen3, you can also put **robotiq_2f_85**. For Gen3 lite, you need to put **gen3_lite_2f**.
+- **gripper** : Name of your robot arm's tool / gripper. See the `kortex_description/grippers` folder to see the available end effector models (or to add your own). The default value is **""**. For Gen3, you can also put **robotiq_2f_85** or **robotiq_2f_140**. For Gen3 lite, you need to put **gen3_lite_2f**.
 - **robot_name** : This is the namespace of the arm that is going to be spawned. It defaults to **my_$(arg arm)** (so my_gen3 for arm="gen3").
 - **use_trajectory_controller** : If this argument is false, one `JointPositionController` per joint will be launched and the arm will offer a basic ROS Control interface to control every joint individually with topics. If this argument is true, a MoveIt! node will be started for the arm and the arm will offer a `FollowJointTrajectory` interface to control the arm (via a `JointTrajectoryController`). The default value is **true**.
 - **use_sim_time** : If this value is true, Gazebo will use simulated time instead of system clock. The default value is **true**.

--- a/third_party/gazebo-pkgs/README.md
+++ b/third_party/gazebo-pkgs/README.md
@@ -1,4 +1,4 @@
-These ROS packages were cloned from https://github.com/JenniferBuehler/gazebo-pkgs into ros_kortex to properly simulate grasping in Gazebo for the Robotiq 2f 85 gripper.
+These ROS packages were cloned from https://github.com/JenniferBuehler/gazebo-pkgs into ros_kortex to properly simulate grasping in Gazebo for the Robotiq 2f 85 gripper and the Robotiq 2f 140 gripper.
 The repository was cloned at commit e54939f6a80982dc1b89c3c2fb288e989f758b20.
 The original readme file follows:
 

--- a/third_party/roboticsgroup_gazebo_plugins/README.md
+++ b/third_party/roboticsgroup_gazebo_plugins/README.md
@@ -1,4 +1,4 @@
-This ROS package was cloned from https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins into ros_kortex to properly simulate mimic joints in Gazebo for the Robotiq 2f 85 gripper.
+This ROS package was cloned from https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins into ros_kortex to properly simulate mimic joints in Gazebo for the Robotiq 2f 85 gripper the Robotiq 2f 140 gripper.
 The repository was cloned at commit 4d93ecd86e4415c3fe74d0027fd41c5e3b39ec44.
 The original readme file follows:
 


### PR DESCRIPTION
Replaced deprecated services PlayCartesianTrajectory and PlayJointTrajectory with ExecuteWaypointTrajectory in example_full_arm_movement.

Added a loop using ValidateWaypointList in example_send_joint_angles to find an almost optimal duration (for the angular waypoint)

Also updated readme files to mention supported robotiq 140 gripper (in Gazebo simulations) 