### PR TITLE
Move arm inbound on init

### DIFF
--- a/kortex_driver/include/kortex_driver/non-generated/kortex_arm_driver.h
+++ b/kortex_driver/include/kortex_driver/non-generated/kortex_arm_driver.h
@@ -80,6 +80,7 @@ class KortexArmDriver
     void initSubscribers();
     void initRosServices();
     void startActionServers();
+    void moveArmWithinJointLimits();
 
   private:
 

--- a/kortex_driver/include/kortex_driver/non-generated/kortex_math_util.h
+++ b/kortex_driver/include/kortex_driver/non-generated/kortex_math_util.h
@@ -27,9 +27,9 @@ public:
     static double wrapRadiansFromMinusPiToPi(double rad_not_wrapped, int& number_of_turns);
     static double wrapDegreesFromZeroTo360(double deg_not_wrapped);
     static double wrapDegreesFromZeroTo360(double deg_not_wrapped, int& number_of_turns);
-    static double wrapValueWithinLimits(double value, double bottom_limit, double top_limit);
     static double relative_position_from_absolute(double absolute_position, double min_value, double max_value);
     static double absolute_position_from_relative(double relative_position, double min_value, double max_value);
+    static double findDeltaFromBoundaries(double value, double limit);
     
     // kortex_driver::Twist helper functions
     static kortex_driver::Twist substractTwists(const kortex_driver::Twist& a, const kortex_driver::Twist& b);

--- a/kortex_driver/include/kortex_driver/non-generated/kortex_math_util.h
+++ b/kortex_driver/include/kortex_driver/non-generated/kortex_math_util.h
@@ -29,7 +29,7 @@ public:
     static double wrapDegreesFromZeroTo360(double deg_not_wrapped, int& number_of_turns);
     static double relative_position_from_absolute(double absolute_position, double min_value, double max_value);
     static double absolute_position_from_relative(double relative_position, double min_value, double max_value);
-    static double findDeltaFromBoundaries(double value, double limit);
+    static float findDistanceToBoundary(float value, float limit);
     
     // kortex_driver::Twist helper functions
     static kortex_driver::Twist substractTwists(const kortex_driver::Twist& a, const kortex_driver::Twist& b);

--- a/kortex_driver/include/kortex_driver/non-generated/kortex_math_util.h
+++ b/kortex_driver/include/kortex_driver/non-generated/kortex_math_util.h
@@ -1,7 +1,7 @@
 #ifndef _KORTEX_MATH_UTIL_H_
 #define _KORTEX_MATH_UTIL_H_
 
-/* 
+/*
  * Copyright (c) 2019 Kinova inc. All rights reserved.
  *
  * This software may be modified and distributed under the 
@@ -27,6 +27,7 @@ public:
     static double wrapRadiansFromMinusPiToPi(double rad_not_wrapped, int& number_of_turns);
     static double wrapDegreesFromZeroTo360(double deg_not_wrapped);
     static double wrapDegreesFromZeroTo360(double deg_not_wrapped, int& number_of_turns);
+    static double wrapValueWithinLimits(double value, double bottom_limit, double top_limit);
     static double relative_position_from_absolute(double absolute_position, double min_value, double max_value);
     static double absolute_position_from_relative(double relative_position, double min_value, double max_value);
     

--- a/kortex_driver/src/non-generated/driver/kortex_math_util.cpp
+++ b/kortex_driver/src/non-generated/driver/kortex_math_util.cpp
@@ -88,6 +88,28 @@ double KortexMathUtil::wrapDegreesFromZeroTo360(double deg_not_wrapped, int& num
     return deg_not_wrapped;
 }
 
+double KortexMathUtil::wrapValueWithinLimits(double value, double bottom_limit, double top_limit)
+{
+    double final_value; 
+    if (value > top_limit) 
+    {
+        // Wrap to top limit
+        final_value = top_limit;
+    }
+    else if (value < bottom_limit) 
+    {
+        // Wrap to top limit
+        final_value = bottom_limit;
+    }
+    else
+    {
+        // value within limits already
+        final_value = value;
+    }
+
+    return final_value;
+}
+
 double KortexMathUtil::relative_position_from_absolute(double absolute_position, double min_value, double max_value)
 {
     double range = max_value - min_value;

--- a/kortex_driver/src/non-generated/driver/kortex_math_util.cpp
+++ b/kortex_driver/src/non-generated/driver/kortex_math_util.cpp
@@ -100,16 +100,16 @@ double KortexMathUtil::absolute_position_from_relative(double relative_position,
     return relative_position * range + min_value;
 }
 
-double KortexMathUtil::findDeltaFromBoundaries(double value, double limit)
+float KortexMathUtil::findDistanceToBoundary(float value, float limit)
 {
-    double delta = std::abs(value) - limit;
+    float distance = std::abs(value) - limit;
 
-    if ( delta < 0 )
+    if ( distance < 0 )
     {
-        delta = 0;
+        distance = 0;
     }
 
-    return delta;
+    return distance;
 }
 
 kortex_driver::Twist KortexMathUtil::substractTwists(const kortex_driver::Twist& a, const kortex_driver::Twist& b)

--- a/kortex_driver/src/non-generated/driver/kortex_math_util.cpp
+++ b/kortex_driver/src/non-generated/driver/kortex_math_util.cpp
@@ -88,28 +88,6 @@ double KortexMathUtil::wrapDegreesFromZeroTo360(double deg_not_wrapped, int& num
     return deg_not_wrapped;
 }
 
-double KortexMathUtil::wrapValueWithinLimits(double value, double bottom_limit, double top_limit)
-{
-    double final_value; 
-    if (value > top_limit) 
-    {
-        // Wrap to top limit
-        final_value = top_limit;
-    }
-    else if (value < bottom_limit) 
-    {
-        // Wrap to top limit
-        final_value = bottom_limit;
-    }
-    else
-    {
-        // value within limits already
-        final_value = value;
-    }
-
-    return final_value;
-}
-
 double KortexMathUtil::relative_position_from_absolute(double absolute_position, double min_value, double max_value)
 {
     double range = max_value - min_value;
@@ -120,6 +98,18 @@ double KortexMathUtil::absolute_position_from_relative(double relative_position,
 {
     double range = max_value - min_value;
     return relative_position * range + min_value;
+}
+
+double KortexMathUtil::findDeltaFromBoundaries(double value, double limit)
+{
+    double delta = std::abs(value) - limit;
+
+    if ( delta < 0 )
+    {
+        delta = 0;
+    }
+
+    return delta;
 }
 
 kortex_driver::Twist KortexMathUtil::substractTwists(const kortex_driver::Twist& a, const kortex_driver::Twist& b)


### PR DESCRIPTION
When the arm is turned off, it might fall and move "out of bounds" for certain joints and it will be impossible to move the arm using moveit or waypoints. 

This function will move the arm within bounds when initializing the ROS driver using jointspeed commands (since waypoints are rejected)