### PR TITLE
fix catkin_make install command

### DIFF
--- a/kortex_examples/CMakeLists.txt
+++ b/kortex_examples/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs message_generation
 
 ## Declare a catkin package
 catkin_package()
-catkin_python_setup()
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 include_directories(include ${PROJECT_SOURCE_DIR}/src)

--- a/kortex_examples/setup.py
+++ b/kortex_examples/setup.py
@@ -1,7 +1,0 @@
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
-
-setup(**generate_distutils_setup(
-    packages=['kortex_examples'],
-    package_dir={'': 'src'}
-))

--- a/kortex_gazebo/CMakeLists.txt
+++ b/kortex_gazebo/CMakeLists.txt
@@ -11,12 +11,16 @@ find_package(gazebo)
 
 catkin_package()
 
-find_package(roslaunch)
+# Install
+install(PROGRAMS
+   scripts/home_robot.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
-foreach(dir config launch meshes urdf)
-	install(DIRECTORY ${dir}/
-		DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+install(DIRECTORY launch
+DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+FILES_MATCHING PATTERN "*.launch"
+)
 
 # Gazebo is compiled with Protobuf 2.6.1 and Kortex with Protobuf 3.5.1
 # The 2.6.1 includes are prepended to the include_directories so the Gazebo plugins we compile here build


### PR DESCRIPTION
Same as #200 : 

> Some of the changes from #49 went missing in action. Bringing them back to life to fix the catkin_make install command that was failing.