### PR TITLE
fix dual driver launching error

### DIFF
--- a/kortex_driver/launch/kortex_arm_driver.launch
+++ b/kortex_driver/launch/kortex_arm_driver.launch
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<launch>
+
+    <!-- Arm configuration -->
+    <arg name="arm" default="gen3"/>
+    <arg name="dof" default="7" if="$(eval arg('arm') == 'gen3')"/> <!-- Number of degrees of freedom of the arm -->
+    <arg name="dof" default="6" if="$(eval arg('arm') == 'gen3_lite')"/> <!-- Number of degrees of freedom of the arm -->
+    <arg name="vision" default="true"/> <!-- True if the arm has a Vision module -->
+    <arg name="use_hard_limits" default="false"/> <!-- Set soft limits as hard limits (Gen3 only) -->
+    <arg name="sim" default="false"/> <!-- Set soft limits as hard limits (Gen3 only) -->
+
+    <!-- Gripper configuration -->
+    <!-- Default gripper for Gen3 is none, default gripper for Gen3 lite is gen3_lite_2f -->
+    <arg name="gripper" default="" if="$(eval arg('arm') == 'gen3')"/>
+    <arg name="gripper" default="gen3_lite_2f" if="$(eval arg('arm') == 'gen3_lite')"/>
+
+    <!-- Namespace -->
+    <arg name="robot_name" default="my_$(arg arm)"/>
+    <arg name="prefix" default=""/>
+
+    <!-- Kortex API options -->
+    <arg name="ip_address" default="192.168.1.10"/>
+    <arg name="username" default="admin"/>
+    <arg name="password" default="admin"/>
+    <arg name="cyclic_data_publish_rate" default="40"/> <!--Hz-->
+    <arg name="api_rpc_timeout_ms" default="2000"/> <!--milliseconds-->
+    <arg name="api_session_inactivity_timeout_ms" default="35000"/> <!--milliseconds-->
+    <arg name="api_connection_inactivity_timeout_ms" default="20000"/> <!--milliseconds-->
+
+    <!-- Action server params -->
+    <arg name="default_goal_time_tolerance" default="0.5"/> <!--seconds-->
+    <arg name="default_goal_tolerance" default="0.005"/> <!--radians-->
+
+    <!-- Start the kortex_driver node -->
+    <node name="$(arg robot_name)_driver" pkg="kortex_driver" type="kortex_arm_driver" output="screen"> <!--launch-prefix="gdb -ex run args"-->
+        <param name="sim" value="$(arg sim)"/>
+        <param name="ip_address" value="$(arg ip_address)"/>
+        <param name="username" value="$(arg username)"/>
+        <param name="password" value="$(arg password)"/>
+        <param name="cyclic_data_publish_rate" value="$(arg cyclic_data_publish_rate)"/>
+        <param name="api_rpc_timeout_ms" value="$(arg api_rpc_timeout_ms)"/>
+        <param name="api_session_inactivity_timeout_ms" value="$(arg api_session_inactivity_timeout_ms)"/>
+        <param name="api_connection_inactivity_timeout_ms" value="$(arg api_connection_inactivity_timeout_ms)"/>
+        <param name="default_goal_time_tolerance" value="$(arg default_goal_time_tolerance)"/>
+        <param name="default_goal_tolerance" value="$(arg default_goal_tolerance)"/>
+        <param name="arm" value="$(arg arm)"/>
+        <param name="gripper" value="$(arg gripper)"/>
+        <param name="dof" value="$(arg dof)"/>
+        <param name="use_hard_limits" value="$(arg use_hard_limits)"/>
+        <param name="robot_name" value="$(arg robot_name)"/>
+        <param name="prefix" value="$(arg prefix)"/>
+        <rosparam command="load" file="$(find kortex_description)/arms/$(arg arm)/$(arg dof)dof/config/joint_limits.yaml" subst_value="true"/>
+        <!-- If there is a gripper, load the active joint names for it -->
+        <rosparam command="load" file="$(find kortex_description)/grippers/$(arg gripper)/config/joint_limits.yaml" unless="$(eval not arg('gripper'))" subst_value="true"/>
+    </node>
+</launch>

--- a/kortex_driver/launch/kortex_dual_driver.launch
+++ b/kortex_driver/launch/kortex_dual_driver.launch
@@ -76,45 +76,42 @@
     />
 
     <!-- Start the left arm kortex_driver node -->
-    <node name="$(arg left_robot_name)_driver" pkg="kortex_driver" type="kortex_arm_driver" output="screen" ns="$(arg left_robot_name)"> launch-prefix="gdb -ex run args"
-        <param name="ip_address" value="$(arg left_ip_address)"/>
-        <param name="username" value="$(arg left_username)"/>
-        <param name="password" value="$(arg left_password)"/>
-        <param name="cyclic_data_publish_rate" value="$(arg left_cyclic_data_publish_rate)"/>
-        <param name="api_rpc_timeout_ms" value="$(arg left_api_rpc_timeout_ms)"/>
-        <param name="api_session_inactivity_timeout_ms" value="$(arg left_api_session_inactivity_timeout_ms)"/>
-        <param name="api_connection_inactivity_timeout_ms" value="$(arg left_api_connection_inactivity_timeout_ms)"/>
-        <param name="default_goal_time_tolerance" value="$(arg left_default_goal_time_tolerance)"/>
-        <param name="default_goal_tolerance" value="$(arg left_default_goal_tolerance)"/>
-        <param name="arm" value="$(arg left_arm)"/>
-        <param name="gripper" value="$(arg left_gripper)"/>
-        <param name="dof" value="$(arg left_dof)"/>
-        <param name="prefix" value="$(arg left_prefix)"/>
-        <param name="robot_name" value="$(arg left_robot_name)"/>
-        <rosparam command="load" file="$(find kortex_description)/arms/$(arg left_arm)/$(arg left_dof)dof/config/joint_limits.yaml" subst_value="true"/>
-        <!-- If there is a gripper, load the active joint names for it -->
-        <rosparam command="load" file="$(find kortex_description)/grippers/$(arg left_gripper)/config/joint_limits.yaml" unless="$(eval not arg('left_gripper'))" subst_value="true"/>
-    </node>
+    <include file="$(find kortex_driver)/launch/kortex_arm_driver.launch">
+        <arg name="sim" value="false"/>
+        <arg name="ip_address" value="$(arg left_ip_address)"/>
+        <arg name="username" value="$(arg left_username)"/>
+        <arg name="password" value="$(arg left_password)"/>
+        <arg name="cyclic_data_publish_rate" value="$(arg left_cyclic_data_publish_rate)"/>
+        <arg name="api_rpc_timeout_ms" value="$(arg left_api_rpc_timeout_ms)"/>
+        <arg name="api_session_inactivity_timeout_ms" value="$(arg left_api_session_inactivity_timeout_ms)"/>
+        <arg name="api_connection_inactivity_timeout_ms" value="$(arg left_api_connection_inactivity_timeout_ms)"/>
+        <arg name="default_goal_time_tolerance" value="$(arg left_default_goal_time_tolerance)"/>
+        <arg name="default_goal_tolerance" value="$(arg left_default_goal_tolerance)"/>
+        <arg name="arm" value="$(arg left_arm)"/>
+        <arg name="gripper" value="$(arg left_gripper)"/>
+        <arg name="dof" value="$(arg left_dof)"/>
+        <arg name="prefix" value="$(arg left_prefix)"/>
+        <arg name="robot_name" value="$(arg left_robot_name)"/>
+    </include>
+
     <!-- Start the right arm kortex_driver node -->
-    <node name="$(arg right_robot_name)_driver" pkg="kortex_driver" type="kortex_arm_driver" output="screen" ns="$(arg right_robot_name)"> launch-prefix="gdb -ex run args"
-        <param name="ip_address" value="$(arg right_ip_address)"/>
-        <param name="username" value="$(arg right_username)"/>
-        <param name="password" value="$(arg right_password)"/>
-        <param name="cyclic_data_publish_rate" value="$(arg right_cyclic_data_publish_rate)"/>
-        <param name="api_rpc_timeout_ms" value="$(arg right_api_rpc_timeout_ms)"/>
-        <param name="api_session_inactivity_timeout_ms" value="$(arg right_api_session_inactivity_timeout_ms)"/>
-        <param name="api_connection_inactivity_timeout_ms" value="$(arg right_api_connection_inactivity_timeout_ms)"/>
-        <param name="default_goal_time_tolerance" value="$(arg right_default_goal_time_tolerance)"/>
-        <param name="default_goal_tolerance" value="$(arg right_default_goal_tolerance)"/>
-        <param name="arm" value="$(arg right_arm)"/>
-        <param name="gripper" value="$(arg right_gripper)"/>
-        <param name="dof" value="$(arg right_dof)"/>
-        <param name="prefix" value="$(arg right_prefix)"/>
-        <param name="robot_name" value="$(arg right_robot_name)"/>
-        <rosparam command="load" file="$(find kortex_description)/arms/$(arg right_arm)/$(arg right_dof)dof/config/joint_limits.yaml" subst_value="true"/>
-        <!-- If there is a gripper, load the active joint names for it -->
-        <rosparam command="load" file="$(find kortex_description)/grippers/$(arg right_gripper)/config/joint_limits.yaml" unless="$(eval not arg('right_gripper'))" subst_value="true"/>
-    </node>
+    <include file="$(find kortex_driver)/launch/kortex_arm_driver.launch">
+        <arg name="sim" value="false"/>
+        <arg name="ip_address" value="$(arg right_ip_address)"/>
+        <arg name="username" value="$(arg right_username)"/>
+        <arg name="password" value="$(arg right_password)"/>
+        <arg name="cyclic_data_publish_rate" value="$(arg right_cyclic_data_publish_rate)"/>
+        <arg name="api_rpc_timeout_ms" value="$(arg right_api_rpc_timeout_ms)"/>
+        <arg name="api_session_inactivity_timeout_ms" value="$(arg right_api_session_inactivity_timeout_ms)"/>
+        <arg name="api_connection_inactivity_timeout_ms" value="$(arg right_api_connection_inactivity_timeout_ms)"/>
+        <arg name="default_goal_time_tolerance" value="$(arg right_default_goal_time_tolerance)"/>
+        <arg name="default_goal_tolerance" value="$(arg right_default_goal_tolerance)"/>
+        <arg name="arm" value="$(arg right_arm)"/>
+        <arg name="gripper" value="$(arg right_gripper)"/>
+        <arg name="dof" value="$(arg right_dof)"/>
+        <arg name="prefix" value="$(arg right_prefix)"/>
+        <arg name="robot_name" value="$(arg right_robot_name)"/>
+    </include>
 
     <!-- Start joint and robot state publisher -->
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
@@ -124,7 +121,7 @@
         </rosparam>
         <param name="use_gui" value="false"/>
     </node>
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher"/>
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
     <!-- Start RViz -->
     <node name="rviz" pkg="rviz" type="rviz" output="log" args="world" if="$(arg start_rviz)"/> 


### PR DESCRIPTION
Same as #213, but for the melodic-devel branch.
Resolves issue #190.

Launching kortex_dual_driver.launch create an error message requires the 'prefix' arg to be set

This is because joint_limits.yaml uses a prefix argument that needs to be defined in the launch file (and passed with subst_value="true"). However, prefix is not defined and cannot be because we need two values to be defined (for left and rigt arm).

To fix that, I created a launch file that only loads joint_limits.yaml and includes this launch file in kortex_dual_driver.launch. That way, it is possible to specify a different prefix argument for the left and right arm.