### PR TITLE
change velocity to rad in topic in/joint_velocity when in gazebo simulation

### DIFF
--- a/kortex_driver/src/non-generated/driver/kortex_arm_simulation.cpp
+++ b/kortex_driver/src/non-generated/driver/kortex_arm_simulation.cpp
@@ -503,6 +503,12 @@ kortex_driver::SendJointSpeedsCommand::Response KortexArmSimulation::SendJointSp
     kortex_driver::Action action;
     action.name = "SendJointSpeedsCommand";
     action.handle.action_type = kortex_driver::ActionType::SEND_JOINT_SPEEDS;
+
+    // Convert degrees in radians
+    for (unsigned int i = 0; i < joint_speeds.joint_speeds.size(); i++)
+    {
+        joint_speeds.joint_speeds[i].value = KortexMathUtil::toDeg(joint_speeds.joint_speeds[i].value);
+    }
     action.oneof_action_parameters.send_joint_speeds.push_back(joint_speeds);
 
     // Fill the velocity commands vector

--- a/kortex_driver/src/non-generated/driver/kortex_arm_simulation.cpp
+++ b/kortex_driver/src/non-generated/driver/kortex_arm_simulation.cpp
@@ -504,10 +504,10 @@ kortex_driver::SendJointSpeedsCommand::Response KortexArmSimulation::SendJointSp
     action.name = "SendJointSpeedsCommand";
     action.handle.action_type = kortex_driver::ActionType::SEND_JOINT_SPEEDS;
 
-    // Convert degrees in radians
+    // Convert radians in degrees
     for (unsigned int i = 0; i < joint_speeds.joint_speeds.size(); i++)
     {
-        joint_speeds.joint_speeds[i].value = KortexMathUtil::toDeg(joint_speeds.joint_speeds[i].value);
+        joint_speeds.joint_speeds[i].value = m_math_util.toDeg(joint_speeds.joint_speeds[i].value);
     }
     action.oneof_action_parameters.send_joint_speeds.push_back(joint_speeds);
 


### PR DESCRIPTION
Resolves #219 

Input for topic `in/joint_velocity` is in rad/s when using a real arm, as specified in the readme file. 
However, when using a Gazebo simulation, this topic's input is in degrees/s.

This PR adds the conversion so that `in/joint_velocity` now takes values in rad/s to make everything more consistent