### PR TITLE
Fix robot state publisher

### DIFF
--- a/kortex_description/launch/visualize.launch
+++ b/kortex_description/launch/visualize.launch
@@ -25,7 +25,7 @@
         <rosparam param="source_list">[base_feedback/joint_state]</rosparam>
         <param name="rate" value="30" />
     </node>
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <!-- Start RViz -->
     <node name="rviz" pkg="rviz" type="rviz" output="log" args="-f base_link" if="$(arg start_rviz)"/> 


### PR DESCRIPTION
`state_publisher` was deprecated in https://github.com/ros/robot_state_publisher/pull/87 and replaced with `robot_state_publisher`