### PR TITLE
fix robot state publisher

### DIFF
--- a/kortex_description/launch/visualize.launch
+++ b/kortex_description/launch/visualize.launch
@@ -26,7 +26,7 @@
         <param name="use_gui" value="true"/>
         <param name="rate" value="30" />
     </node>
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <!-- Start RViz -->
     <node name="rviz" pkg="rviz" type="rviz" output="log" args="-f base_link" if="$(arg start_rviz)"/> 


### PR DESCRIPTION
Same as #228 for the melodic branch.

> `state_publisher` was deprecated in https://github.com/ros/robot_state_publisher/pull/87 and replaced with `robot_state_publisher`