### PR TITLE
Send request to set cartesian reference frame

### DIFF
--- a/kortex_examples/src/full_arm/example_full_arm_movement.py
+++ b/kortex_examples/src/full_arm/example_full_arm_movement.py
@@ -162,7 +162,7 @@ class ExampleFullArmMovement:
 
         # Call the service
         try:
-            self.set_cartesian_reference_frame()
+            self.set_cartesian_reference_frame(req)
         except rospy.ServiceException:
             rospy.logerr("Failed to call SetCartesianReferenceFrame")
             return False


### PR DESCRIPTION
I compared this example between the C++ and the Python version.
Shouldn't the created request be included as the args when calling ```self.set_cartesian_reference_frame()``` ?