### PR TITLE
Fix typos in joint limits

### DIFF
--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -96,7 +96,7 @@
         link="${prefix}half_arm_1_link" />
       <axis
         xyz="0 0 1" />
-      <limit lower="-2.41" upper="2.41" effort="39" velocity="1.3963" />
+      <limit lower="-2.24" upper="2.24" effort="39" velocity="1.3963" />
     </joint>
     <link name="${prefix}half_arm_2_link">
       <inertial>
@@ -166,7 +166,7 @@
         link="${prefix}forearm_link" />
       <axis
         xyz="0 0 1" />
-      <limit lower="-2.66" upper="2.66" effort="39" velocity="1.3963" />
+      <limit lower="-2.57" upper="2.57" effort="39" velocity="1.3963" />
     </joint>
     <link name="${prefix}spherical_wrist_1_link">
       <inertial>
@@ -236,7 +236,7 @@
         link="${prefix}spherical_wrist_2_link" />
       <axis
         xyz="0 0 1" />
-      <limit lower="-2.23" upper="2.23" effort="9" velocity="1.2218" />
+      <limit lower="-2.09" upper="2.09" effort="9" velocity="1.2218" />
     </joint>
     <xacro:if value="${vision}">
     <link name="${prefix}bracelet_link">


### PR DESCRIPTION
I was running into some confusing errors until I realized that the URDF joint limits don't match the robots default joint limits in https://www.kinovarobotics.com/uploads/User-Guide-Gen3-R07.pdf, so it was very easy to accidentally have my code try to send the robot past its safety limits. Hopefully this change makes sense.