### PR TITLE
Fix joint limits pertaining to Gen3 Manuals

### DIFF
--- a/kortex_description/arms/gen3/6dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/6dof/urdf/gen3_macro.xacro
@@ -84,7 +84,7 @@
       <parent link="${prefix}shoulder_link" />
       <child link="${prefix}bicep_link" />
       <axis xyz="0 0 1" />
-      <limit lower="-2.41" upper="2.41" effort="39" velocity="1.3963" />
+      <limit lower="-2.24" upper="2.24" effort="39" velocity="1.3963" />
     </joint>
     <link name="${prefix}forearm_link">
       <inertial>
@@ -113,7 +113,7 @@
       <parent link="${prefix}bicep_link" />
       <child link="${prefix}forearm_link" />
       <axis xyz="0 0 1" />
-      <limit lower="-2.66" upper="2.66" effort="39" velocity="1.3963" />
+      <limit lower="-2.57" upper="2.57" effort="39" velocity="1.3963" />
     </joint>
     <link name="${prefix}spherical_wrist_1_link">
       <inertial>
@@ -171,7 +171,7 @@
       <parent link="${prefix}spherical_wrist_1_link" />
       <child link="${prefix}spherical_wrist_2_link" />
       <axis xyz="0 0 1" />
-      <limit lower="-2.23" upper="2.23" effort="9" velocity="1.2218" />
+      <limit lower="-2.09" upper="2.09" effort="9" velocity="1.2218" />
     </joint>
     <xacro:if value="${vision}">
     <link name="${prefix}bracelet_link">

--- a/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
+++ b/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro
@@ -96,7 +96,7 @@
         link="${prefix}half_arm_1_link" />
       <axis
         xyz="0 0 1" />
-      <limit lower="-2.41" upper="2.41" effort="39" velocity="1.3963" />
+      <limit lower="-2.24" upper="2.24" effort="39" velocity="1.3963" />
     </joint>
     <link name="${prefix}half_arm_2_link">
       <inertial>
@@ -166,7 +166,7 @@
         link="${prefix}forearm_link" />
       <axis
         xyz="0 0 1" />
-      <limit lower="-2.66" upper="2.66" effort="39" velocity="1.3963" />
+      <limit lower="-2.57" upper="2.57" effort="39" velocity="1.3963" />
     </joint>
     <link name="${prefix}spherical_wrist_1_link">
       <inertial>
@@ -236,7 +236,7 @@
         link="${prefix}spherical_wrist_2_link" />
       <axis
         xyz="0 0 1" />
-      <limit lower="-2.23" upper="2.23" effort="9" velocity="1.2218" />
+      <limit lower="-2.09" upper="2.09" effort="9" velocity="1.2218" />
     </joint>
     <xacro:if value="${vision}">
     <link name="${prefix}bracelet_link">

--- a/kortex_description/arms/gen3_lite/6dof/urdf/gen3_lite_macro.xacro
+++ b/kortex_description/arms/gen3_lite/6dof/urdf/gen3_lite_macro.xacro
@@ -61,7 +61,7 @@
       <parent link="${prefix}base_link" />
       <child link="${prefix}shoulder_link" />
       <axis xyz="0 0 1" />
-      <limit lower="-2.69" upper="2.69" effort="10" velocity="1.6" />
+      <limit lower="-2.68" upper="2.68" effort="10" velocity="1.6" />
     </joint>
     <link name="${prefix}arm_link">
       <inertial>
@@ -93,7 +93,7 @@
       <parent link="${prefix}shoulder_link" />
       <child link="${prefix}arm_link" />
       <axis xyz="0 0 1" />
-      <limit lower="-2.69" upper="2.69" effort="14" velocity="1.6" />
+      <limit lower="-2.61" upper="2.61" effort="14" velocity="1.6" />
     </joint>
     <link name="${prefix}forearm_link">
       <inertial>
@@ -125,7 +125,7 @@
       <parent link="${prefix}arm_link" />
       <child link="${prefix}forearm_link" />
       <axis xyz="0 0 1" />
-      <limit lower="-2.69" upper="2.69" effort="10" velocity="1.6" />
+      <limit lower="-2.61" upper="2.61" effort="10" velocity="1.6" />
     </joint>
     <link name="${prefix}lower_wrist_link">
       <inertial>
@@ -157,7 +157,7 @@
       <parent link="${prefix}forearm_link" />
       <child link="${prefix}lower_wrist_link" />
       <axis xyz="0 0 1" />
-      <limit lower="-2.59" upper="2.59" effort="7" velocity="1.6" />
+      <limit lower="-2.6" upper="2.6" effort="7" velocity="1.6" />
     </joint>
     <link name="${prefix}upper_wrist_link">
       <inertial>
@@ -189,7 +189,7 @@
       <parent link="${prefix}lower_wrist_link" />
       <child link="${prefix}upper_wrist_link" />
       <axis xyz="0 0 1" />
-      <limit lower="-2.57" upper="2.57" effort="7" velocity="1.6" />
+      <limit lower="-2.53" upper="2.53" effort="7" velocity="1.6" />
     </joint>
     <link name="${prefix}end_effector_link"/>
     <joint name="${prefix}joint_6" type="revolute">
@@ -197,7 +197,7 @@
       <parent link="${prefix}upper_wrist_link" />
       <child link="${prefix}end_effector_link" />
       <axis xyz="0 0 1" />
-      <limit lower="-2.59" upper="2.59" effort="7" velocity="3.2" />
+      <limit lower="-2.6" upper="2.6" effort="7" velocity="3.2" />
     </joint>
     <link name="${prefix}dummy_link" />
     <joint name="${prefix}end_effector" type="fixed">


### PR DESCRIPTION
* This PR matches the joint limits for Gen3 and Gen3 Lite arms.
* Refer to [pg 97-98](https://www.kinovarobotics.com/uploads/User-Guide-Gen3-R07.pdf) for the Gen3 changes and [pg 71-72](https://artifactory.kinovaapps.com/ui/api/v1/download?repoKey=generic-public&path=Documentation%2FGen3%20lite%2FTechnical%20documentation%2FUser%20Guide%2FGen3_lite_USER_GUIDE_R03.pdf) for the Gen3 lite changes.
* This PR addresses the following issues - #293, #285, and #245.