### PR TITLE
add note that branch is no longer maintained

### DIFF
--- a/kortex_driver/readme.md
+++ b/kortex_driver/readme.md
@@ -12,7 +12,11 @@
 
 # Kortex Driver
 
-# **Note:** There have been many changes made between versions 1.1.7 and 2.0.0 of the ROS driver. You can view the changes and learn the steps to follow to adapt your code in [this section](#compatibility).
+# Important 
+
+This branch is no longer maintained as Ubuntu 18.04 Bionic Beaver and ROS Melodic are end-of-life.
+
+There have been many changes made between versions 1.1.7 and 2.0.0 of the ROS driver. You can view the changes and learn the steps to follow to adapt your code in [this section](#compatibility).
 
 <!-- MarkdownTOC -->
 ## Table of contents

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,10 @@
 # ros_kortex
 ROS Kortex is the official ROS package to interact with Kortex and its related products. It is built upon the Kortex API, documentation for which can be found in the [GitHub Kortex repository](https://github.com/Kinovarobotics/kortex).
 
+## Important
+
+This branch is no longer maintained as Ubuntu 18.04 Bionic Beaver and ROS Melodic are end-of-life.
+
 ## Download links
 
 You can refer to the [Kortex repository "Download links" section](https://github.com/Kinovarobotics/kortex#download-links) to download the firmware package and the release notes.


### PR DESCRIPTION
Deprecating melodic-devel branch because Ubuntu18 and ROS Melodic is now EOL