### PR TITLE
Added extra world option

### DIFF
--- a/kortex_description/robots/kortex_robot.xacro
+++ b/kortex_description/robots/kortex_robot.xacro
@@ -2,7 +2,7 @@
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-    <xacro:macro name="load_robot" params="arm gripper dof vision sim prefix">
+    <xacro:macro name="load_robot" params="world:=True arm gripper dof vision sim prefix">
             
         <!-- Files to include -->
         <xacro:include filename="$(find kortex_description)/arms/${arm}/${dof}dof/urdf/${arm}_macro.xacro" />
@@ -22,7 +22,7 @@
         <!-- Run the macros -->
 
         <!-- For gazebo-->
-        <xacro:if value="${sim}">
+        <xacro:if value="${sim and world}">
             <link name="world" />
             <joint name="world_to_root" type="fixed">
                 <child link="${prefix}base_link" />


### PR DESCRIPTION
This pull request addresses an integration problem where the created "world" link causes conflicts when simulating robotic arm placed on top of Clearpath Husky UGV on Gazebo. By introducing a new "world" parameter in the load_robot macro, with a default value of True, developers can have the flexibility to set it as False in their customized URDF files, controlling where and how to put "world" link in their own urdf files.