### PR TITLE
Update example_move_it_trajectories.py

### DIFF
--- a/kortex_examples/src/move_it/example_move_it_trajectories.py
+++ b/kortex_examples/src/move_it/example_move_it_trajectories.py
@@ -38,7 +38,7 @@
 # Modified by Alexandre Vannobel to test the FollowJointTrajectory Action Server for the Kinova Gen3 robot
 
 # To run this node in a given namespace with rosrun (for example 'my_gen3'), start a Kortex driver and then run : 
-# rosrun kortex_examples example_moveit_trajectories.py __ns:=my_gen3
+# rosrun kortex_examples example_move_it_trajectories.py __ns:=my_gen3
 
 import sys
 import time


### PR DESCRIPTION
there is a little "_" missing at the end of description, used to be "rosrun kortex_example example_moveit_tran......."